### PR TITLE
Fix linking failures due to PIE

### DIFF
--- a/nlvm/llgen.nim
+++ b/nlvm/llgen.nim
@@ -6203,7 +6203,7 @@ proc writeOutput(g: LLGen, project: string) =
   discard getTargetFromTriple(g.tgt, addr(tr), nil)
 
   var reloc = llvm.RelocDefault
-  if optGenDynLib in g.config.globalOptions and
+  if optGenDynLib in g.config.globalOptions or
       ospNeedsPIC in platform.OS[g.config.target.targetOS].props:
     reloc = llvm.RelocPIC
 

--- a/nlvm/llgen.nim
+++ b/nlvm/llgen.nim
@@ -6202,6 +6202,7 @@ proc writeOutput(g: LLGen, project: string) =
   var tr: llvm.TargetRef
   discard getTargetFromTriple(g.tgt, addr(tr), nil)
 
+  #PIC/PIE is preferred/default on most platforms:
   var reloc = llvm.RelocPIC
 
   let cgl =

--- a/nlvm/llgen.nim
+++ b/nlvm/llgen.nim
@@ -6202,8 +6202,9 @@ proc writeOutput(g: LLGen, project: string) =
   var tr: llvm.TargetRef
   discard getTargetFromTriple(g.tgt, addr(tr), nil)
 
-  #PIC/PIE is preferred/default on most platforms:
-  var reloc = llvm.RelocPIC
+  # PIC/PIE is used by default when linking on certain platforms to enable address space randomization:
+  # https://stackoverflow.com/q/43367427
+  let reloc = llvm.RelocPIC
 
   let cgl =
     if optOptimizeSpeed in g.config.options: llvm.CodeGenLevelAggressive

--- a/nlvm/llgen.nim
+++ b/nlvm/llgen.nim
@@ -6202,10 +6202,7 @@ proc writeOutput(g: LLGen, project: string) =
   var tr: llvm.TargetRef
   discard getTargetFromTriple(g.tgt, addr(tr), nil)
 
-  var reloc = llvm.RelocDefault
-  if optGenDynLib in g.config.globalOptions or
-      ospNeedsPIC in platform.OS[g.config.target.targetOS].props:
-    reloc = llvm.RelocPIC
+  var reloc = llvm.RelocPIC
 
   let cgl =
     if optOptimizeSpeed in g.config.options: llvm.CodeGenLevelAggressive


### PR DESCRIPTION
In the future maybe we should instruct llvm to generate PIE instead, or at least make it an option. (the performance impact of PIE is neglible on x86_64)