### PR TITLE
ORCv2 JIT

### DIFF
--- a/llvm/llvm.nim
+++ b/llvm/llvm.nim
@@ -69,6 +69,8 @@ type
   comdat{.pure, final.} = object
   opaqueModuleFlagEntry{.pure, final.} = object
   OpaqueBinary{.pure, final.} = object
+  orcOpaqueJITStack{.pure, final.} = object
+  OpaqueError{.pure, final.} = object
 
   # Funny type names that came out of c2nim
   int64T = int64
@@ -132,11 +134,14 @@ include llvm/Core
 include llvm/DebugInfo
 include llvm/BitReader
 include llvm/BitWriter
+include llvm/Error
 include llvm/IRReader
 include llvm/Linker
 include llvm/Target
 include llvm/TargetMachine
 include llvm/Transforms/PassManagerBuilder
+
+include llvm/OrcBindings
 
 include preprocessed
 
@@ -414,10 +419,10 @@ proc getMDKindIDInContext*(c: ContextRef, name: string): cuint =
 proc createStringAttribute*(c: ContextRef, k, v: string): AttributeRef =
   createStringAttribute(c, k.cstring, k.len.cuint, v.cstring, v.len.cuint)
 
-
 proc appendBasicBlockInContext*(
     b: BuilderRef, c: ContextRef, name: cstring): BasicBlockRef =
   let
     pre = b.getInsertBlock()
     f = pre.getBasicBlockParent()
   appendBasicBlockInContext(c, f, name)
+

--- a/llvm/llvm.nim
+++ b/llvm/llvm.nim
@@ -72,6 +72,36 @@ type
   orcOpaqueJITStack{.pure, final.} = object
   OpaqueError{.pure, final.} = object
 
+  ## Orc.nim
+  OrcOpaqueExecutionSession{.pure, final.} = object
+  OrcOpaqueSymbolStringPool{.pure, final.} = object
+  OrcOpaqueJITDylib{.pure, final.} = object
+  OrcOpaqueSymbolStringPoolEntry{.pure, final.} = object
+  OrcOpaqueMaterializationUnit{.pure, final.} = object
+  OrcOpaqueMaterializationResponsibility{.pure, final.} = object
+  OrcOpaqueResourceTracker{.pure, final.} = object
+  OrcOpaqueDefinitionGenerator{.pure, final.} = object
+  OrcOpaqueLookupState{.pure, final.} = object
+  OrcOpaqueThreadSafeContext{.pure, final.} = object
+  OrcOpaqueThreadSafeModule{.pure, final.} = object
+  OrcOpaqueJITTargetMachineBuilder{.pure, final.} = object
+  OrcOpaqueObjectLayer{.pure, final.} = object
+  OrcOpaqueObjectLinkingLayer{.pure, final.} = object
+  OrcOpaqueIRTransformLayer{.pure, final.} = object
+  OrcOpaqueObjectTransformLayer{.pure, final.} = object
+  OrcOpaqueIndirectStubsManager{.pure, final.} = object
+  OrcOpaqueLazyCallThroughManager{.pure, final.} = object
+  OrcOpaqueDumpObjects{.pure, final.} = object
+
+  ## ExecutionEngine.nim
+  OpaqueGenericValue{.pure, final.} = object
+  OpaqueExecutionEngine{.pure, final.} = object
+  OpaqueMCJITMemoryManager{.pure, final.} = object
+
+  ## LLJIT.nim
+  OrcOpaqueLLJITBuilder{.pure, final.} = object
+  OrcOpaqueLLJIT{.pure, final.} = object
+
   # Funny type names that came out of c2nim
   int64T = int64
   uint64T = uint64
@@ -141,7 +171,10 @@ include llvm/Target
 include llvm/TargetMachine
 include llvm/Transforms/PassManagerBuilder
 
-include llvm/OrcBindings
+include llvm/Orc
+include llvm/OrcEE
+include llvm/ExecutionEngine
+include llvm/LLJIT
 
 include preprocessed
 

--- a/llvm/llvm/Error.nim
+++ b/llvm/llvm/Error.nim
@@ -11,10 +11,20 @@
 ## |*                                                                            *|
 ## \*===----------------------------------------------------------------------===
 
-## !!!Ignored construct:  # LLVM_C_ERROR_H [NewLine] # LLVM_C_ERROR_H [NewLine] # llvm-c/ExternC.h [NewLine] LLVM_C_EXTERN_C_BEGIN # LLVMErrorSuccess 0 [NewLine] *
+#import
+#  ExternC
+
+## LLVM_C_EXTERN_C_BEGIN
+
+const
+  ErrorSuccess* = 0
+
+## *
 ##  Opaque reference to an error instance. Null serves as the 'success' value.
-##  typedef struct LLVMOpaqueError * LLVMErrorRef ;
-## Error: expected ';'!!!
+##
+
+type
+  ErrorRef* = ptr OpaqueError
 
 ## *
 ##  Error type identifier.

--- a/llvm/llvm/ExecutionEngine.nim
+++ b/llvm/llvm/ExecutionEngine.nim
@@ -1,0 +1,187 @@
+## ===-- llvm-c/ExecutionEngine.h - ExecutionEngine Lib C Iface --*- C++ -*-===*\
+## |*                                                                            *|
+## |* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+## |* Exceptions.                                                                *|
+## |* See https://llvm.org/LICENSE.txt for license information.                  *|
+## |* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+## |*                                                                            *|
+## |*===----------------------------------------------------------------------===*|
+## |*                                                                            *|
+## |* This header declares the C interface to libLLVMExecutionEngine.o, which    *|
+## |* implements various analyses of the LLVM IR.                                *|
+## |*                                                                            *|
+## |* Many exotic languages can interoperate with C code but have a harder time  *|
+## |* with C++ due to name mangling. So in addition to C, this interface enables *|
+## |* tools written in such languages.                                           *|
+## |*                                                                            *|
+## \*===----------------------------------------------------------------------===
+
+#import
+#  ExternC, Target, TargetMachine, Types
+
+## LLVM_C_EXTERN_C_BEGIN
+## *
+##  @defgroup LLVMCExecutionEngine Execution Engine
+##  @ingroup LLVMC
+##
+##  @{
+##
+
+proc linkInMCJIT*() {.importc: "LLVMLinkInMCJIT", dynlib: LLVMLib.}
+proc linkInInterpreter*() {.importc: "LLVMLinkInInterpreter", dynlib: LLVMLib.}
+type
+  GenericValueRef* = ptr OpaqueGenericValue
+  ExecutionEngineRef* = ptr OpaqueExecutionEngine
+  MCJITMemoryManagerRef* = ptr OpaqueMCJITMemoryManager
+  MCJITCompilerOptions* {.bycopy.} = object
+    OptLevel*: cuint
+    CodeModel*: CodeModel
+    NoFramePointerElim*: Bool
+    EnableFastISel*: Bool
+    MCJMM*: MCJITMemoryManagerRef
+
+
+## ===-- Operations on generic values --------------------------------------===
+
+proc createGenericValueOfInt*(Ty: TypeRef; N: culonglong; IsSigned: Bool): GenericValueRef {.
+    importc: "LLVMCreateGenericValueOfInt", dynlib: LLVMLib.}
+proc createGenericValueOfPointer*(P: pointer): GenericValueRef {.
+    importc: "LLVMCreateGenericValueOfPointer", dynlib: LLVMLib.}
+proc createGenericValueOfFloat*(Ty: TypeRef; N: cdouble): GenericValueRef {.
+    importc: "LLVMCreateGenericValueOfFloat", dynlib: LLVMLib.}
+proc genericValueIntWidth*(GenValRef: GenericValueRef): cuint {.
+    importc: "LLVMGenericValueIntWidth", dynlib: LLVMLib.}
+proc genericValueToInt*(GenVal: GenericValueRef; IsSigned: Bool): culonglong {.
+    importc: "LLVMGenericValueToInt", dynlib: LLVMLib.}
+proc genericValueToPointer*(GenVal: GenericValueRef): pointer {.
+    importc: "LLVMGenericValueToPointer", dynlib: LLVMLib.}
+proc genericValueToFloat*(TyRef: TypeRef; GenVal: GenericValueRef): cdouble {.
+    importc: "LLVMGenericValueToFloat", dynlib: LLVMLib.}
+proc disposeGenericValue*(GenVal: GenericValueRef) {.
+    importc: "LLVMDisposeGenericValue", dynlib: LLVMLib.}
+## ===-- Operations on execution engines -----------------------------------===
+
+proc createExecutionEngineForModule*(OutEE: ptr ExecutionEngineRef;
+                                        M: ModuleRef; OutError: cstringArray): Bool {.
+    importc: "LLVMCreateExecutionEngineForModule", dynlib: LLVMLib.}
+proc createInterpreterForModule*(OutInterp: ptr ExecutionEngineRef;
+                                    M: ModuleRef; OutError: cstringArray): Bool {.
+    importc: "LLVMCreateInterpreterForModule", dynlib: LLVMLib.}
+proc createJITCompilerForModule*(OutJIT: ptr ExecutionEngineRef;
+                                    M: ModuleRef; OptLevel: cuint;
+                                    OutError: cstringArray): Bool {.
+    importc: "LLVMCreateJITCompilerForModule", dynlib: LLVMLib.}
+proc initializeMCJITCompilerOptions*(Options: ptr MCJITCompilerOptions;
+                                        SizeOfOptions: csize_t) {.
+    importc: "LLVMInitializeMCJITCompilerOptions", dynlib: LLVMLib.}
+## *
+##  Create an MCJIT execution engine for a module, with the given options. It is
+##  the responsibility of the caller to ensure that all fields in Options up to
+##  the given SizeOfOptions are initialized. It is correct to pass a smaller
+##  value of SizeOfOptions that omits some fields. The canonical way of using
+##  this is:
+##
+##  MCJITCompilerOptions options;
+##  InitializeMCJITCompilerOptions(&options, sizeof(options));
+##  ... fill in those options you care about
+##  CreateMCJITCompilerForModule(&jit, mod, &options, sizeof(options),
+##                                   &error);
+##
+##  Note that this is also correct, though possibly suboptimal:
+##
+##  CreateMCJITCompilerForModule(&jit, mod, 0, 0, &error);
+##
+
+proc createMCJITCompilerForModule*(OutJIT: ptr ExecutionEngineRef;
+                                      M: ModuleRef;
+                                      Options: ptr MCJITCompilerOptions;
+                                      SizeOfOptions: csize_t;
+                                      OutError: cstringArray): Bool {.
+    importc: "LLVMCreateMCJITCompilerForModule", dynlib: LLVMLib.}
+proc disposeExecutionEngine*(EE: ExecutionEngineRef) {.
+    importc: "LLVMDisposeExecutionEngine", dynlib: LLVMLib.}
+proc runStaticConstructors*(EE: ExecutionEngineRef) {.
+    importc: "LLVMRunStaticConstructors", dynlib: LLVMLib.}
+proc runStaticDestructors*(EE: ExecutionEngineRef) {.
+    importc: "LLVMRunStaticDestructors", dynlib: LLVMLib.}
+proc runFunctionAsMain*(EE: ExecutionEngineRef; F: ValueRef; ArgC: cuint;
+                           ArgV: cstringArray; EnvP: cstringArray): cint {.
+    importc: "LLVMRunFunctionAsMain", dynlib: LLVMLib.}
+proc runFunction*(EE: ExecutionEngineRef; F: ValueRef; NumArgs: cuint;
+                     Args: ptr GenericValueRef): GenericValueRef {.
+    importc: "LLVMRunFunction", dynlib: LLVMLib.}
+proc freeMachineCodeForFunction*(EE: ExecutionEngineRef; F: ValueRef) {.
+    importc: "LLVMFreeMachineCodeForFunction", dynlib: LLVMLib.}
+proc addModule*(EE: ExecutionEngineRef; M: ModuleRef) {.
+    importc: "LLVMAddModule", dynlib: LLVMLib.}
+proc removeModule*(EE: ExecutionEngineRef; M: ModuleRef;
+                      OutMod: ptr ModuleRef; OutError: cstringArray): Bool {.
+    importc: "LLVMRemoveModule", dynlib: LLVMLib.}
+proc findFunction*(EE: ExecutionEngineRef; Name: cstring;
+                      OutFn: ptr ValueRef): Bool {.
+    importc: "LLVMFindFunction", dynlib: LLVMLib.}
+proc recompileAndRelinkFunction*(EE: ExecutionEngineRef; Fn: ValueRef): pointer {.
+    importc: "LLVMRecompileAndRelinkFunction", dynlib: LLVMLib.}
+proc getExecutionEngineTargetData*(EE: ExecutionEngineRef): TargetDataRef {.
+    importc: "LLVMGetExecutionEngineTargetData", dynlib: LLVMLib.}
+proc getExecutionEngineTargetMachine*(EE: ExecutionEngineRef): TargetMachineRef {.
+    importc: "LLVMGetExecutionEngineTargetMachine", dynlib: LLVMLib.}
+proc addGlobalMapping*(EE: ExecutionEngineRef; Global: ValueRef;
+                          Addr: pointer) {.importc: "LLVMAddGlobalMapping",
+    dynlib: LLVMLib.}
+proc getPointerToGlobal*(EE: ExecutionEngineRef; Global: ValueRef): pointer {.
+    importc: "LLVMGetPointerToGlobal", dynlib: LLVMLib.}
+proc getGlobalValueAddress*(EE: ExecutionEngineRef; Name: cstring): uint64_t {.
+    importc: "LLVMGetGlobalValueAddress", dynlib: LLVMLib.}
+proc getFunctionAddress*(EE: ExecutionEngineRef; Name: cstring): uint64_t {.
+    importc: "LLVMGetFunctionAddress", dynlib: LLVMLib.}
+## / Returns true on error, false on success. If true is returned then the error
+## / message is copied to OutStr and cleared in the ExecutionEngine instance.
+
+proc executionEngineGetErrMsg*(EE: ExecutionEngineRef;
+                                  OutError: cstringArray): Bool {.
+    importc: "LLVMExecutionEngineGetErrMsg", dynlib: LLVMLib.}
+## ===-- Operations on memory managers -------------------------------------===
+
+type
+  MemoryManagerAllocateCodeSectionCallback* = proc (Opaque: pointer;
+      Size: pointer; Alignment: cuint; SectionID: cuint; SectionName: cstring): ptr uint8_t
+  MemoryManagerAllocateDataSectionCallback* = proc (Opaque: pointer;
+      Size: pointer; Alignment: cuint; SectionID: cuint; SectionName: cstring;
+      IsReadOnly: Bool): ptr uint8_t
+  MemoryManagerFinalizeMemoryCallback* = proc (Opaque: pointer;
+      ErrMsg: cstringArray): Bool
+  MemoryManagerDestroyCallback* = proc (Opaque: pointer)
+
+## *
+##  Create a simple custom MCJIT memory manager. This memory manager can
+##  intercept allocations in a module-oblivious way. This will return NULL
+##  if any of the passed functions are NULL.
+##
+##  @param Opaque An opaque client object to pass back to the callbacks.
+##  @param AllocateCodeSection Allocate a block of memory for executable code.
+##  @param AllocateDataSection Allocate a block of memory for data.
+##  @param FinalizeMemory Set page permissions and flush cache. Return 0 on
+##    success, 1 on error.
+##
+
+proc createSimpleMCJITMemoryManager*(Opaque: pointer; AllocateCodeSection: MemoryManagerAllocateCodeSectionCallback;
+    AllocateDataSection: MemoryManagerAllocateDataSectionCallback;
+    FinalizeMemory: MemoryManagerFinalizeMemoryCallback; Destroy: MemoryManagerDestroyCallback): MCJITMemoryManagerRef {.
+    importc: "LLVMCreateSimpleMCJITMemoryManager", dynlib: LLVMLib.}
+proc disposeMCJITMemoryManager*(MM: MCJITMemoryManagerRef) {.
+    importc: "LLVMDisposeMCJITMemoryManager", dynlib: LLVMLib.}
+## ===-- JIT Event Listener functions -------------------------------------===
+
+proc createGDBRegistrationListener*(): JITEventListenerRef {.
+    importc: "LLVMCreateGDBRegistrationListener", dynlib: LLVMLib.}
+proc createIntelJITEventListener*(): JITEventListenerRef {.
+    importc: "LLVMCreateIntelJITEventListener", dynlib: LLVMLib.}
+proc createOProfileJITEventListener*(): JITEventListenerRef {.
+    importc: "LLVMCreateOProfileJITEventListener", dynlib: LLVMLib.}
+proc createPerfJITEventListener*(): JITEventListenerRef {.
+    importc: "LLVMCreatePerfJITEventListener", dynlib: LLVMLib.}
+## *
+##  @}
+##
+## _C_EXTERN_C_END

--- a/llvm/llvm/LLJIT.nim
+++ b/llvm/llvm/LLJIT.nim
@@ -1,0 +1,253 @@
+## ===----------- llvm-c/LLJIT.h - OrcV2 LLJIT C bindings --------*- C++ -*-===*\
+## |*                                                                            *|
+## |* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+## |* Exceptions.                                                                *|
+## |* See https://llvm.org/LICENSE.txt for license information.                  *|
+## |* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+## |*                                                                            *|
+## |*===----------------------------------------------------------------------===*|
+## |*                                                                            *|
+## |* This header declares the C interface to the LLJIT class in                 *|
+## |* libLLVMOrcJIT.a, which provides a simple MCJIT-like ORC JIT.               *|
+## |*                                                                            *|
+## |* Many exotic languages can interoperate with C code but have a harder time  *|
+## |* with C++ due to name mangling. So in addition to C, this interface enables *|
+## |* tools written in such languages.                                           *|
+## |*                                                                            *|
+## |* Note: This interface is experimental. It is *NOT* stable, and may be       *|
+## |*       changed without warning. Only C API usage documentation is           *|
+## |*       provided. See the C++ documentation for all higher level ORC API     *|
+## |*       details.                                                             *|
+## |*                                                                            *|
+## \*===----------------------------------------------------------------------===
+
+#import
+#  llvm-c/Error, llvm-c/Orc, llvm-c/TargetMachine, llvm-c/Types
+
+## LLVM_C_EXTERN_C_BEGIN
+## *
+##  A function for constructing an ObjectLinkingLayer instance to be used
+##  by an LLJIT instance.
+##
+##  Clients can call LLVMOrcLLJITBuilderSetObjectLinkingLayerCreator to
+##  set the creator function to use when constructing an LLJIT instance.
+##  This can be used to override the default linking layer implementation
+##  that would otherwise be chosen by LLJITBuilder.
+##
+##  Object linking layers returned by this function will become owned by the
+##  LLJIT instance. The client is not responsible for managing their lifetimes
+##  after the function returns.
+##
+
+type
+  OrcLLJITBuilderObjectLinkingLayerCreatorFunction* = proc (Ctx: pointer;
+      ES: OrcExecutionSessionRef; Triple: cstring): OrcObjectLayerRef
+
+## *
+##  A reference to an orc::LLJITBuilder instance.
+##
+
+type
+  OrcLLJITBuilderRef* = ptr OrcOpaqueLLJITBuilder
+
+## *
+##  A reference to an orc::LLJIT instance.
+##
+
+type
+  OrcLLJITRef* = ptr OrcOpaqueLLJIT
+
+## *
+##  Create an OrcLLJITBuilder.
+##
+##  The client owns the resulting LLJITBuilder and should dispose of it using
+##  OrcDisposeLLJITBuilder once they are done with it.
+##
+
+proc orcCreateLLJITBuilder*(): OrcLLJITBuilderRef {.
+    importc: "LLVMOrcCreateLLJITBuilder", dynlib: LLVMLib.}
+## *
+##  Dispose of an OrcLLJITBuilderRef. This should only be called if ownership
+##  has not been passed to OrcCreateLLJIT (e.g. because some error prevented
+##  that function from being called).
+##
+
+proc orcDisposeLLJITBuilder*(Builder: OrcLLJITBuilderRef) {.
+    importc: "LLVMOrcDisposeLLJITBuilder", dynlib: LLVMLib.}
+## *
+##  Set the JITTargetMachineBuilder to be used when constructing the LLJIT
+##  instance. Calling this function is optional: if it is not called then the
+##  LLJITBuilder will use JITTargeTMachineBuilder::detectHost to construct a
+##  JITTargetMachineBuilder.
+##
+##  This function takes ownership of the JTMB argument: clients should not
+##  dispose of the JITTargetMachineBuilder after calling this function.
+##
+
+proc orcLLJITBuilderSetJITTargetMachineBuilder*(
+    Builder: OrcLLJITBuilderRef; JTMB: OrcJITTargetMachineBuilderRef) {.
+    importc: "LLVMOrcLLJITBuilderSetJITTargetMachineBuilder", dynlib: LLVMLib.}
+## *
+##  Set an ObjectLinkingLayer creator function for this LLJIT instance.
+##
+
+proc orcLLJITBuilderSetObjectLinkingLayerCreator*(
+    Builder: OrcLLJITBuilderRef;
+    F: OrcLLJITBuilderObjectLinkingLayerCreatorFunction; Ctx: pointer) {.
+    importc: "LLVMOrcLLJITBuilderSetObjectLinkingLayerCreator", dynlib: LLVMLib.}
+## *
+##  Create an LLJIT instance from an LLJITBuilder.
+##
+##  This operation takes ownership of the Builder argument: clients should not
+##  dispose of the builder after calling this function (even if the function
+##  returns an error). If a null Builder argument is provided then a
+##  default-constructed LLJITBuilder will be used.
+##
+##  On success the resulting LLJIT instance is uniquely owned by the client and
+##  automatically manages the memory of all JIT'd code and all modules that are
+##  transferred to it (e.g. via OrcLLJITAddIRModule). Disposing of the
+##  LLJIT instance will free all memory managed by the JIT, including JIT'd code
+##  and not-yet compiled modules.
+##
+
+proc orcCreateLLJIT*(Result: ptr OrcLLJITRef;
+                     Builder: OrcLLJITBuilderRef): ErrorRef {.
+    importc: "LLVMOrcCreateLLJIT", dynlib: LLVMLib.}
+## *
+##  Dispose of an LLJIT instance.
+##
+
+proc orcDisposeLLJIT*(J: OrcLLJITRef): ErrorRef {.
+    importc: "LLVMOrcDisposeLLJIT", dynlib: LLVMLib.}
+## *
+##  Get a reference to the ExecutionSession for this LLJIT instance.
+##
+##  The ExecutionSession is owned by the LLJIT instance. The client is not
+##  responsible for managing its memory.
+##
+
+proc orcLLJITGetExecutionSession*(J: OrcLLJITRef): OrcExecutionSessionRef {.
+    importc: "LLVMOrcLLJITGetExecutionSession", dynlib: LLVMLib.}
+## *
+##  Return a reference to the Main JITDylib.
+##
+##  The JITDylib is owned by the LLJIT instance. The client is not responsible
+##  for managing its memory.
+##
+
+proc orcLLJITGetMainJITDylib*(J: OrcLLJITRef): OrcJITDylibRef {.
+    importc: "LLVMOrcLLJITGetMainJITDylib", dynlib: LLVMLib.}
+## *
+##  Return the target triple for this LLJIT instance. This string is owned by
+##  the LLJIT instance and should not be freed by the client.
+##
+
+proc orcLLJITGetTripleString*(J: OrcLLJITRef): cstring {.
+    importc: "LLVMOrcLLJITGetTripleString", dynlib: LLVMLib.}
+## *
+##  Returns the global prefix character according to the LLJIT's DataLayout.
+##
+
+proc orcLLJITGetGlobalPrefix*(J: OrcLLJITRef): char {.
+    importc: "LLVMOrcLLJITGetGlobalPrefix", dynlib: LLVMLib.}
+## *
+##  Mangles the given string according to the LLJIT instance's DataLayout, then
+##  interns the result in the SymbolStringPool and returns a reference to the
+##  pool entry. Clients should call OrcReleaseSymbolStringPoolEntry to
+##  decrement the ref-count on the pool entry once they are finished with this
+##  value.
+##
+
+proc orcLLJITMangleAndIntern*(J: OrcLLJITRef; UnmangledName: cstring): OrcSymbolStringPoolEntryRef {.
+    importc: "LLVMOrcLLJITMangleAndIntern", dynlib: LLVMLib.}
+## *
+##  Add a buffer representing an object file to the given JITDylib in the given
+##  LLJIT instance. This operation transfers ownership of the buffer to the
+##  LLJIT instance. The buffer should not be disposed of or referenced once this
+##  function returns.
+##
+##  Resources associated with the given object will be tracked by the given
+##  JITDylib's default resource tracker.
+##
+
+proc orcLLJITAddObjectFile*(J: OrcLLJITRef; JD: OrcJITDylibRef;
+                               ObjBuffer: MemoryBufferRef): ErrorRef {.
+    importc: "LLVMOrcLLJITAddObjectFile", dynlib: LLVMLib.}
+## *
+##  Add a buffer representing an object file to the given ResourceTracker's
+##  JITDylib in the given LLJIT instance. This operation transfers ownership of
+##  the buffer to the LLJIT instance. The buffer should not be disposed of or
+##  referenced once this function returns.
+##
+##  Resources associated with the given object will be tracked by ResourceTracker
+##  RT.
+##
+
+proc orcLLJITAddObjectFileWithRT*(J: OrcLLJITRef;
+                                     RT: OrcResourceTrackerRef;
+                                     ObjBuffer: MemoryBufferRef): ErrorRef {.
+    importc: "LLVMOrcLLJITAddObjectFileWithRT", dynlib: LLVMLib.}
+## *
+##  Add an IR module to the given JITDylib in the given LLJIT instance. This
+##  operation transfers ownership of the TSM argument to the LLJIT instance.
+##  The TSM argument should not be disposed of or referenced once this
+##  function returns.
+##
+##  Resources associated with the given Module will be tracked by the given
+##  JITDylib's default resource tracker.
+##
+
+proc orcLLJITAddLLVMIRModule*(J: OrcLLJITRef; JD: OrcJITDylibRef;
+                                 TSM: OrcThreadSafeModuleRef): ErrorRef {.
+    importc: "LLVMOrcLLJITAddLLVMIRModule", dynlib: LLVMLib.}
+## *
+##  Add an IR module to the given ResourceTracker's JITDylib in the given LLJIT
+##  instance. This operation transfers ownership of the TSM argument to the LLJIT
+##  instance. The TSM argument should not be disposed of or referenced once this
+##  function returns.
+##
+##  Resources associated with the given Module will be tracked by ResourceTracker
+##  RT.
+##
+
+proc orcLLJITAddLLVMIRModuleWithRT*(J: OrcLLJITRef;
+                                       JD: OrcResourceTrackerRef;
+                                       TSM: OrcThreadSafeModuleRef): ErrorRef {.
+    importc: "LLVMOrcLLJITAddLLVMIRModuleWithRT", dynlib: LLVMLib.}
+## *
+##  Look up the given symbol in the main JITDylib of the given LLJIT instance.
+##
+##  This operation does not take ownership of the Name argument.
+##
+
+proc orcLLJITLookup*(J: OrcLLJITRef; Result: ptr OrcExecutorAddress;
+                        Name: cstring): ErrorRef {.
+    importc: "LLVMOrcLLJITLookup", dynlib: LLVMLib.}
+## *
+##  Returns a non-owning reference to the LLJIT instance's object linking layer.
+##
+
+proc orcLLJITGetObjLinkingLayer*(J: OrcLLJITRef): OrcObjectLayerRef {.
+    importc: "LLVMOrcLLJITGetObjLinkingLayer", dynlib: LLVMLib.}
+## *
+##  Returns a non-owning reference to the LLJIT instance's object linking layer.
+##
+
+proc orcLLJITGetObjTransformLayer*(J: OrcLLJITRef): OrcObjectTransformLayerRef {.
+    importc: "LLVMOrcLLJITGetObjTransformLayer", dynlib: LLVMLib.}
+## *
+##  Returns a non-owning reference to the LLJIT instance's IR transform layer.
+##
+
+proc orcLLJITGetIRTransformLayer*(J: OrcLLJITRef): OrcIRTransformLayerRef {.
+    importc: "LLVMOrcLLJITGetIRTransformLayer", dynlib: LLVMLib.}
+## *
+##  Get the LLJIT instance's default data layout string.
+##
+##  This string is owned by the LLJIT instance and does not need to be freed
+##  by the caller.
+##
+
+proc orcLLJITGetDataLayoutStr*(J: OrcLLJITRef): cstring {.
+    importc: "LLVMOrcLLJITGetDataLayoutStr", dynlib: LLVMLib.}
+## _C_EXTERN_C_END

--- a/llvm/llvm/Orc.nim
+++ b/llvm/llvm/Orc.nim
@@ -1074,7 +1074,7 @@ proc orcDisposeThreadSafeContext*(TSCtx: OrcThreadSafeContextRef) {.
 ##
 
 proc orcCreateNewThreadSafeModule*(M: ModuleRef;
-                                      TSCtx: OrcThreadSafeContextRef): OrcThreadSafeModuleRef {.
+                                   TSCtx: OrcThreadSafeContextRef): OrcThreadSafeModuleRef {.
     importc: "LLVMOrcCreateNewThreadSafeModule", dynlib: LLVMLib.}
 ## *
 ##  Dispose of a ThreadSafeModule. This should only be called if ownership has

--- a/llvm/llvm/Orc.nim
+++ b/llvm/llvm/Orc.nim
@@ -1,0 +1,1269 @@
+
+## ===---------------- llvm-c/Orc.h - OrcV2 C bindings -----------*- C++ -*-===*\
+## |*                                                                            *|
+## |* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+## |* Exceptions.                                                                *|
+## |* See https://llvm.org/LICENSE.txt for license information.                  *|
+## |* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+## |*                                                                            *|
+## |*===----------------------------------------------------------------------===*|
+## |*                                                                            *|
+## |* This header declares the C interface to libLLVMOrcJIT.a, which implements  *|
+## |* JIT compilation of LLVM IR. Minimal documentation of C API specific issues *|
+## |* (especially memory ownership rules) is provided. Core Orc concepts are     *|
+## |* documented in llvm/docs/ORCv2.rst and APIs are documented in the C++       *|
+## |* headers                                                                    *|
+## |*                                                                            *|
+## |* Many exotic languages can interoperate with C code but have a harder time  *|
+## |* with C++ due to name mangling. So in addition to C, this interface enables *|
+## |* tools written in such languages.                                           *|
+## |*                                                                            *|
+## |* Note: This interface is experimental. It is *NOT* stable, and may be       *|
+## |*       changed without warning. Only C API usage documentation is           *|
+## |*       provided. See the C++ documentation for all higher level ORC API     *|
+## |*       details.                                                             *|
+## |*                                                                            *|
+## \*===----------------------------------------------------------------------===
+
+#import
+#  Error, TargetMachine, Types
+
+##  LLVM_C_EXTERN_C_BEGIN
+## *
+##  Represents an address in the executor process.
+##
+
+type
+  OrcJITTargetAddress* = uint64_t
+
+## *
+##  Represents an address in the executor process.
+##
+
+type
+  OrcExecutorAddress* = uint64_t
+
+## *
+##  Represents generic linkage flags for a symbol definition.
+##
+
+type
+  JITSymbolGenericFlags* {.size: sizeof(cint).} = enum
+    JITSymbolGenericFlagsExported = 1'u shl 0,
+    JITSymbolGenericFlagsWeak = 1'u shl 1,
+    JITSymbolGenericFlagsCallable = 1'u shl 2,
+    JITSymbolGenericFlagsMaterializationSideEffectsOnly = 1'u shl 3
+
+
+## *
+##  Represents target specific flags for a symbol definition.
+##
+
+type
+  JITSymbolTargetFlags* = uint8_t
+
+## *
+##  Represents the linkage flags for a symbol definition.
+##
+
+type
+  JITSymbolFlags* {.bycopy.} = object
+    GenericFlags*: uint8_t
+    TargetFlags*: uint8_t
+
+
+## *
+##  Represents an evaluated symbol address and flags.
+##
+
+type
+  JITEvaluatedSymbol* {.bycopy.} = object
+    Address*: OrcExecutorAddress
+    Flags*: JITSymbolFlags
+
+
+## *
+##  A reference to an orc::ExecutionSession instance.
+##
+
+type
+  OrcExecutionSessionRef* = ptr OrcOpaqueExecutionSession
+
+## *
+##  Error reporter function.
+##
+
+type
+  OrcErrorReporterFunction* = proc (Ctx: pointer; Err: ErrorRef)
+
+## *
+##  A reference to an orc::SymbolStringPool.
+##
+
+type
+  OrcSymbolStringPoolRef* = ptr OrcOpaqueSymbolStringPool
+
+## *
+##  A reference to an orc::SymbolStringPool table entry.
+##
+
+type
+  OrcSymbolStringPoolEntryRef* = ptr OrcOpaqueSymbolStringPoolEntry
+
+## *
+##  Represents a pair of a symbol name and LLVMJITSymbolFlags.
+##
+
+type
+  OrcCSymbolFlagsMapPair* {.bycopy.} = object
+    Name*: OrcSymbolStringPoolEntryRef
+    Flags*: JITSymbolFlags
+
+
+## *
+##  Represents a list of (SymbolStringPtr, JITSymbolFlags) pairs that can be used
+##  to construct a SymbolFlagsMap.
+##
+
+type
+  OrcCSymbolFlagsMapPairs* = ptr OrcCSymbolFlagsMapPair
+
+## *
+##  Represents a pair of a symbol name and an evaluated symbol.
+##
+
+type
+  JITCSymbolMapPair* {.bycopy.} = object
+    Name*: OrcSymbolStringPoolEntryRef
+    Sym*: JITEvaluatedSymbol
+
+
+## *
+##  Represents a list of (SymbolStringPtr, JITEvaluatedSymbol) pairs that can be
+##  used to construct a SymbolMap.
+##
+
+type
+  OrcCSymbolMapPairs* = ptr JITCSymbolMapPair
+
+## *
+##  Represents a SymbolAliasMapEntry
+##
+
+type
+  OrcCSymbolAliasMapEntry* {.bycopy.} = object
+    Name*: OrcSymbolStringPoolEntryRef
+    Flags*: JITSymbolFlags
+
+
+## *
+##  Represents a pair of a symbol name and SymbolAliasMapEntry.
+##
+
+type
+  OrcCSymbolAliasMapPair* {.bycopy.} = object
+    Name*: OrcSymbolStringPoolEntryRef
+    Entry*: OrcCSymbolAliasMapEntry
+
+
+## *
+##  Represents a list of (SymbolStringPtr, (SymbolStringPtr, JITSymbolFlags))
+##  pairs that can be used to construct a SymbolFlagsMap.
+##
+
+type
+  OrcCSymbolAliasMapPairs* = ptr OrcCSymbolAliasMapPair
+
+## *
+##  A reference to an orc::JITDylib instance.
+##
+
+type
+  OrcJITDylibRef* = ptr OrcOpaqueJITDylib
+
+## *
+##  Represents a list of OrcSymbolStringPoolEntryRef and the associated
+##  length.
+##
+
+type
+  OrcCSymbolsList* {.bycopy.} = object
+    Symbols*: ptr OrcSymbolStringPoolEntryRef
+    Length*: csize_t
+
+
+## *
+##  Represents a pair of a JITDylib and OrcCSymbolsList.
+##
+
+type
+  OrcCDependenceMapPair* {.bycopy.} = object
+    JD*: OrcJITDylibRef
+    Names*: OrcCSymbolsList
+
+
+## *
+##  Represents a list of (JITDylibRef, (OrcSymbolStringPoolEntryRef*,
+##  size_t)) pairs that can be used to construct a SymbolDependenceMap.
+##
+
+type
+  OrcCDependenceMapPairs* = ptr OrcCDependenceMapPair
+
+## *
+##  Lookup kind. This can be used by definition generators when deciding whether
+##  to produce a definition for a requested symbol.
+##
+##  This enum should be kept in sync with llvm::orc::LookupKind.
+##
+
+type
+  OrcLookupKind* {.size: sizeof(cint).} = enum
+    OrcLookupKindStatic, OrcLookupKindDLSym
+
+
+## *
+##  JITDylib lookup flags. This can be used by definition generators when
+##  deciding whether to produce a definition for a requested symbol.
+##
+##  This enum should be kept in sync with llvm::orc::JITDylibLookupFlags.
+##
+
+type
+  OrcJITDylibLookupFlags* {.size: sizeof(cint).} = enum
+    OrcJITDylibLookupFlagsMatchExportedSymbolsOnly,
+    OrcJITDylibLookupFlagsMatchAllSymbols
+
+
+## *
+##  Symbol lookup flags for lookup sets. This should be kept in sync with
+##  llvm::orc::SymbolLookupFlags.
+##
+
+type
+  OrcSymbolLookupFlags* {.size: sizeof(cint).} = enum
+    OrcSymbolLookupFlagsRequiredSymbol,
+    OrcSymbolLookupFlagsWeaklyReferencedSymbol
+
+
+## *
+##  An element type for a symbol lookup set.
+##
+
+type
+  OrcCLookupSetElement* {.bycopy.} = object
+    Name*: OrcSymbolStringPoolEntryRef
+    LookupFlags*: OrcSymbolLookupFlags
+
+
+## *
+##  A set of symbols to look up / generate.
+##
+##  The list is terminated with an element containing a null pointer for the
+##  Name field.
+##
+##  If a client creates an instance of this type then they are responsible for
+##  freeing it, and for ensuring that all strings have been retained over the
+##  course of its life. Clients receiving a copy from a callback are not
+##  responsible for managing lifetime or retain counts.
+##
+
+type
+  OrcCLookupSet* = ptr OrcCLookupSetElement
+
+## *
+##  A reference to a uniquely owned orc::MaterializationUnit instance.
+##
+
+type
+  OrcMaterializationUnitRef* = ptr OrcOpaqueMaterializationUnit
+
+## *
+##  A reference to a uniquely owned orc::MaterializationResponsibility instance.
+##
+##  Ownership must be passed to a lower-level layer in a JIT stack.
+##
+
+type
+  OrcMaterializationResponsibilityRef* = ptr OrcOpaqueMaterializationResponsibility
+
+## *
+##  A MaterializationUnit materialize callback.
+##
+##  Ownership of the Ctx and MR arguments passes to the callback which must
+##  adhere to the OrcMaterializationResponsibilityRef contract (see comment
+##  for that type).
+##
+##  If this callback is called then the OrcMaterializationUnitDestroy
+##  callback will NOT be called.
+##
+
+type
+  OrcMaterializationUnitMaterializeFunction* = proc (Ctx: pointer;
+      MR: OrcMaterializationResponsibilityRef)
+
+## *
+##  A MaterializationUnit discard callback.
+##
+##  Ownership of JD and Symbol remain with the caller: These arguments should
+##  not be disposed of or released.
+##
+
+type
+  OrcMaterializationUnitDiscardFunction* = proc (Ctx: pointer;
+      JD: OrcJITDylibRef; Symbol: OrcSymbolStringPoolEntryRef)
+
+## *
+##  A MaterializationUnit destruction callback.
+##
+##  If a custom MaterializationUnit is destroyed before its Materialize
+##  function is called then this function will be called to provide an
+##  opportunity for the underlying program representation to be destroyed.
+##
+
+type
+  OrcMaterializationUnitDestroyFunction* = proc (Ctx: pointer)
+
+## *
+##  A reference to an orc::ResourceTracker instance.
+##
+
+type
+  OrcResourceTrackerRef* = ptr OrcOpaqueResourceTracker
+
+## *
+##  A reference to an orc::DefinitionGenerator.
+##
+
+type
+  OrcDefinitionGeneratorRef* = ptr OrcOpaqueDefinitionGenerator
+
+## *
+##  An opaque lookup state object. Instances of this type can be captured to
+##  suspend a lookup while a custom generator function attempts to produce a
+##  definition.
+##
+##  If a client captures a lookup state object then they must eventually call
+##  OrcLookupStateContinueLookup to restart the lookup. This is required
+##  in order to release memory allocated for the lookup state, even if errors
+##  have occurred while the lookup was suspended (if these errors have made the
+##  lookup impossible to complete then it will issue its own error before
+##  destruction).
+##
+
+type
+  OrcLookupStateRef* = ptr OrcOpaqueLookupState
+
+## *
+##  A custom generator function. This can be used to create a custom generator
+##  object using OrcCreateCustomCAPIDefinitionGenerator. The resulting
+##  object can be attached to a JITDylib, via OrcJITDylibAddGenerator, to
+##  receive callbacks when lookups fail to match existing definitions.
+##
+##  GeneratorObj will contain the address of the custom generator object.
+##
+##  Ctx will contain the context object passed to
+##  OrcCreateCustomCAPIDefinitionGenerator.
+##
+##  LookupState will contain a pointer to an OrcLookupStateRef object. This
+##  can optionally be modified to make the definition generation process
+##  asynchronous: If the LookupStateRef value is copied, and the original
+##  OrcLookupStateRef set to null, the lookup will be suspended. Once the
+##  asynchronous definition process has been completed clients must call
+##  OrcLookupStateContinueLookup to continue the lookup (this should be
+##  done unconditionally, even if errors have occurred in the mean time, to
+##  free the lookup state memory and notify the query object of the failures).
+##  If LookupState is captured this function must return ErrorSuccess.
+##
+##  The Kind argument can be inspected to determine the lookup kind (e.g.
+##  as-if-during-static-link, or as-if-during-dlsym).
+##
+##  The JD argument specifies which JITDylib the definitions should be generated
+##  into.
+##
+##  The JDLookupFlags argument can be inspected to determine whether the original
+##  lookup included non-exported symobls.
+##
+##  Finally, the LookupSet argument contains the set of symbols that could not
+##  be found in JD already (the set of generation candidates).
+##
+
+type
+  OrcCAPIDefinitionGeneratorTryToGenerateFunction* = proc (
+      GeneratorObj: OrcDefinitionGeneratorRef; Ctx: pointer;
+      LookupState: ptr OrcLookupStateRef; Kind: OrcLookupKind;
+      JD: OrcJITDylibRef; JDLookupFlags: OrcJITDylibLookupFlags;
+      LookupSet: OrcCLookupSet; LookupSetSize: csize_t): ErrorRef
+
+## *
+##  Predicate function for SymbolStringPoolEntries.
+##
+
+type
+  OrcSymbolPredicate* = proc (Ctx: pointer; Sym: OrcSymbolStringPoolEntryRef): cint
+
+## *
+##  A reference to an orc::ThreadSafeContext instance.
+##
+
+type
+  OrcThreadSafeContextRef* = ptr OrcOpaqueThreadSafeContext
+
+## *
+##  A reference to an orc::ThreadSafeModule instance.
+##
+
+type
+  OrcThreadSafeModuleRef* = ptr OrcOpaqueThreadSafeModule
+
+## *
+##  A function for inspecting/mutating IR modules, suitable for use with
+##  OrcThreadSafeModuleWithModuleDo.
+##
+
+type
+  OrcGenericIRModuleOperationFunction* = proc (Ctx: pointer; M: ModuleRef): ErrorRef
+
+## *
+##  A reference to an orc::JITTargetMachineBuilder instance.
+##
+
+type
+  OrcJITTargetMachineBuilderRef* = ptr OrcOpaqueJITTargetMachineBuilder
+
+## *
+##  A reference to an orc::ObjectLayer instance.
+##
+
+type
+  OrcObjectLayerRef* = ptr OrcOpaqueObjectLayer
+
+## *
+##  A reference to an orc::ObjectLinkingLayer instance.
+##
+
+type
+  OrcObjectLinkingLayerRef* = ptr OrcOpaqueObjectLinkingLayer
+
+## *
+##  A reference to an orc::IRTransformLayer instance.
+##
+
+type
+  OrcIRTransformLayerRef* = ptr OrcOpaqueIRTransformLayer
+
+## *
+##  A function for applying transformations as part of an transform layer.
+##
+##  Implementations of this type are responsible for managing the lifetime
+##  of the Module pointed to by ModInOut: If the ModuleRef value is
+##  overwritten then the function is responsible for disposing of the incoming
+##  module. If the module is simply accessed/mutated in-place then ownership
+##  returns to the caller and the function does not need to do any lifetime
+##  management.
+##
+##  Clients can call OrcLLJITGetIRTransformLayer to obtain the transform
+##  layer of a LLJIT instance, and use OrcIRTransformLayerSetTransform
+##  to set the function. This can be used to override the default transform
+##  layer.
+##
+
+type
+  OrcIRTransformLayerTransformFunction* = proc (Ctx: pointer;
+      ModInOut: ptr OrcThreadSafeModuleRef;
+      MR: OrcMaterializationResponsibilityRef): ErrorRef
+
+## *
+##  A reference to an orc::ObjectTransformLayer instance.
+##
+
+type
+  OrcObjectTransformLayerRef* = ptr OrcOpaqueObjectTransformLayer
+
+## *
+##  A function for applying transformations to an object file buffer.
+##
+##  Implementations of this type are responsible for managing the lifetime
+##  of the memory buffer pointed to by ObjInOut: If the MemoryBufferRef
+##  value is overwritten then the function is responsible for disposing of the
+##  incoming buffer. If the buffer is simply accessed/mutated in-place then
+##  ownership returns to the caller and the function does not need to do any
+##  lifetime management.
+##
+##  The transform is allowed to return an error, in which case the ObjInOut
+##  buffer should be disposed of and set to null.
+##
+
+type
+  OrcObjectTransformLayerTransformFunction* = proc (Ctx: pointer;
+      ObjInOut: ptr MemoryBufferRef): ErrorRef
+
+## *
+##  A reference to an orc::IndirectStubsManager instance.
+##
+
+type
+  OrcIndirectStubsManagerRef* = ptr OrcOpaqueIndirectStubsManager
+
+## *
+##  A reference to an orc::LazyCallThroughManager instance.
+##
+
+type
+  OrcLazyCallThroughManagerRef* = ptr OrcOpaqueLazyCallThroughManager
+
+## *
+##  A reference to an orc::DumpObjects object.
+##
+##  Can be used to dump object files to disk with unique names. Useful as an
+##  ObjectTransformLayer transform.
+##
+
+type
+  OrcDumpObjectsRef* = ptr OrcOpaqueDumpObjects
+
+## *
+##  Attach a custom error reporter function to the ExecutionSession.
+##
+##  The error reporter will be called to deliver failure notices that can not be
+##  directly reported to a caller. For example, failure to resolve symbols in
+##  the JIT linker is typically reported via the error reporter (callers
+##  requesting definitions from the JIT will typically be delivered a
+##  FailureToMaterialize error instead).
+##
+
+proc orcExecutionSessionSetErrorReporter*(ES: OrcExecutionSessionRef;
+    ReportError: OrcErrorReporterFunction; Ctx: pointer) {.
+    importc: "LLVMOrcExecutionSessionSetErrorReporter", dynlib: LLVMLib.}
+## *
+##  Return a reference to the SymbolStringPool for an ExecutionSession.
+##
+##  Ownership of the pool remains with the ExecutionSession: The caller is
+##  not required to free the pool.
+##
+
+proc orcExecutionSessionGetSymbolStringPool*(ES: OrcExecutionSessionRef): OrcSymbolStringPoolRef {.
+    importc: "LLVMOrcExecutionSessionGetSymbolStringPool", dynlib: LLVMLib.}
+## *
+##  Clear all unreferenced symbol string pool entries.
+##
+##  This can be called at any time to release unused entries in the
+##  ExecutionSession's string pool. Since it locks the pool (preventing
+##  interning of any new strings) it is recommended that it only be called
+##  infrequently, ideally when the caller has reason to believe that some
+##  entries will have become unreferenced, e.g. after removing a module or
+##  closing a JITDylib.
+##
+
+proc orcSymbolStringPoolClearDeadEntries*(SSP: OrcSymbolStringPoolRef) {.
+    importc: "LLVMOrcSymbolStringPoolClearDeadEntries", dynlib: LLVMLib.}
+## *
+##  Intern a string in the ExecutionSession's SymbolStringPool and return a
+##  reference to it. This increments the ref-count of the pool entry, and the
+##  returned value should be released once the client is done with it by
+##  calling OrReleaseSymbolStringPoolEntry.
+##
+##  Since strings are uniqued within the SymbolStringPool
+##  OrcSymbolStringPoolEntryRefs can be compared by value to test string
+##  equality.
+##
+##  Note that this function does not perform linker-mangling on the string.
+##
+
+proc orcExecutionSessionIntern*(ES: OrcExecutionSessionRef; Name: cstring): OrcSymbolStringPoolEntryRef {.
+    importc: "LLVMOrcExecutionSessionIntern", dynlib: LLVMLib.}
+## *
+##  Increments the ref-count for a SymbolStringPool entry.
+##
+
+proc orcRetainSymbolStringPoolEntry*(S: OrcSymbolStringPoolEntryRef) {.
+    importc: "LLVMOrcRetainSymbolStringPoolEntry", dynlib: LLVMLib.}
+## *
+##  Reduces the ref-count for of a SymbolStringPool entry.
+##
+
+proc orcReleaseSymbolStringPoolEntry*(S: OrcSymbolStringPoolEntryRef) {.
+    importc: "LLVMOrcReleaseSymbolStringPoolEntry", dynlib: LLVMLib.}
+proc orcSymbolStringPoolEntryStr*(S: OrcSymbolStringPoolEntryRef): cstring {.
+    importc: "LLVMOrcSymbolStringPoolEntryStr", dynlib: LLVMLib.}
+## *
+##  Reduces the ref-count of a ResourceTracker.
+##
+
+proc orcReleaseResourceTracker*(RT: OrcResourceTrackerRef) {.
+    importc: "LLVMOrcReleaseResourceTracker", dynlib: LLVMLib.}
+## *
+##  Transfers tracking of all resources associated with resource tracker SrcRT
+##  to resource tracker DstRT.
+##
+
+proc orcResourceTrackerTransferTo*(SrcRT: OrcResourceTrackerRef;
+                                      DstRT: OrcResourceTrackerRef) {.
+    importc: "LLVMOrcResourceTrackerTransferTo", dynlib: LLVMLib.}
+## *
+##  Remove all resources associated with the given tracker. See
+##  ResourceTracker::remove().
+##
+
+proc orcResourceTrackerRemove*(RT: OrcResourceTrackerRef): ErrorRef {.
+    importc: "LLVMOrcResourceTrackerRemove", dynlib: LLVMLib.}
+## *
+##  Dispose of a JITDylib::DefinitionGenerator. This should only be called if
+##  ownership has not been passed to a JITDylib (e.g. because some error
+##  prevented the client from calling OrcJITDylibAddGenerator).
+##
+
+proc orcDisposeDefinitionGenerator*(DG: OrcDefinitionGeneratorRef) {.
+    importc: "LLVMOrcDisposeDefinitionGenerator", dynlib: LLVMLib.}
+## *
+##  Dispose of a MaterializationUnit.
+##
+
+proc orcDisposeMaterializationUnit*(MU: OrcMaterializationUnitRef) {.
+    importc: "LLVMOrcDisposeMaterializationUnit", dynlib: LLVMLib.}
+## *
+##  Create a custom MaterializationUnit.
+##
+##  Name is a name for this MaterializationUnit to be used for identification
+##  and logging purposes (e.g. if this MaterializationUnit produces an
+##  object buffer then the name of that buffer will be derived from this name).
+##
+##  The Syms list contains the names and linkages of the symbols provided by this
+##  unit. This function takes ownership of the elements of the Syms array. The
+##  Name fields of the array elements are taken to have been retained for this
+##  function. The client should *not* release the elements of the array, but is
+##  still responsible for destroyingthe array itself.
+##
+##  The InitSym argument indicates whether or not this MaterializationUnit
+##  contains static initializers. If three are no static initializers (the common
+##  case) then this argument should be null. If there are static initializers
+##  then InitSym should be set to a unique name that also appears in the Syms
+##  list with the JITSymbolGenericFlagsMaterializationSideEffectsOnly flag
+##  set. This function takes ownership of the InitSym, which should have been
+##  retained twice on behalf of this function: once for the Syms entry and once
+##  for InitSym. If clients wish to use the InitSym value after this function
+##  returns they must retain it once more for themselves.
+##
+##  If any of the symbols in the Syms list is looked up then the Materialize
+##  function will be called.
+##
+##  If any of the symbols in the Syms list is overridden then the Discard
+##  function will be called.
+##
+##  The caller owns the underling MaterializationUnit and is responsible for
+##  either passing it to a JITDylib (via OrcJITDylibDefine) or disposing
+##  of it by calling OrcDisposeMaterializationUnit.
+##
+
+proc orcCreateCustomMaterializationUnit*(Name: cstring; Ctx: pointer;
+    Syms: OrcCSymbolFlagsMapPairs; NumSyms: csize_t;
+    InitSym: OrcSymbolStringPoolEntryRef;
+    Materialize: OrcMaterializationUnitMaterializeFunction;
+    Discard: OrcMaterializationUnitDiscardFunction;
+    Destroy: OrcMaterializationUnitDestroyFunction): OrcMaterializationUnitRef {.
+    importc: "LLVMOrcCreateCustomMaterializationUnit", dynlib: LLVMLib.}
+## *
+##  Create a MaterializationUnit to define the given symbols as pointing to
+##  the corresponding raw addresses.
+##
+##  This function takes ownership of the elements of the Syms array. The Name
+##  fields of the array elements are taken to have been retained for this
+##  function. This allows the following pattern...
+##
+##    size_t NumPairs;
+##    OrcCSymbolMapPairs Sym;
+##    -- Build Syms array --
+##    OrcMaterializationUnitRef MU =
+##        OrcAbsoluteSymbols(Syms, NumPairs);
+##
+##  ... without requiring cleanup of the elements of the Sym array afterwards.
+##
+##  The client is still responsible for deleting the Sym array itself.
+##
+##  If a client wishes to reuse elements of the Sym array after this call they
+##  must explicitly retain each of the elements for themselves.
+##
+
+proc orcAbsoluteSymbols*(Syms: OrcCSymbolMapPairs; NumPairs: csize_t): OrcMaterializationUnitRef {.
+    importc: "LLVMOrcAbsoluteSymbols", dynlib: LLVMLib.}
+## *
+##  Create a MaterializationUnit to define lazy re-expots. These are callable
+##  entry points that call through to the given symbols.
+##
+##  This function takes ownership of the CallableAliases array. The Name
+##  fields of the array elements are taken to have been retained for this
+##  function. This allows the following pattern...
+##
+##    size_t NumPairs;
+##    OrcCSymbolAliasMapPairs CallableAliases;
+##    -- Build CallableAliases array --
+##    OrcMaterializationUnitRef MU =
+##       OrcLazyReexports(LCTM, ISM, JD, CallableAliases, NumPairs);
+##
+##  ... without requiring cleanup of the elements of the CallableAliases array afterwards.
+##
+##  The client is still responsible for deleting the CallableAliases array itself.
+##
+##  If a client wishes to reuse elements of the CallableAliases array after this call they
+##  must explicitly retain each of the elements for themselves.
+##
+
+proc orcLazyReexports*(LCTM: OrcLazyCallThroughManagerRef;
+                          ISM: OrcIndirectStubsManagerRef;
+                          SourceRef: OrcJITDylibRef;
+                          CallableAliases: OrcCSymbolAliasMapPairs;
+                          NumPairs: csize_t): OrcMaterializationUnitRef {.
+    importc: "LLVMOrcLazyReexports", dynlib: LLVMLib.}
+##  TODO: ImplSymbolMad SrcJDLoc
+## *
+##  Disposes of the passed MaterializationResponsibility object.
+##
+##  This should only be done after the symbols covered by the object have either
+##  been resolved and emitted (via
+##  OrcMaterializationResponsibilityNotifyResolved and
+##  OrcMaterializationResponsibilityNotifyEmitted) or failed (via
+##  OrcMaterializationResponsibilityFailMaterialization).
+##
+
+proc orcDisposeMaterializationResponsibility*(
+    MR: OrcMaterializationResponsibilityRef) {.
+    importc: "LLVMOrcDisposeMaterializationResponsibility", dynlib: LLVMLib.}
+## *
+##  Returns the target JITDylib that these symbols are being materialized into.
+##
+
+proc orcMaterializationResponsibilityGetTargetDylib*(
+    MR: OrcMaterializationResponsibilityRef): OrcJITDylibRef {.
+    importc: "LLVMOrcMaterializationResponsibilityGetTargetDylib", dynlib: LLVMLib.}
+## *
+##  Returns the ExecutionSession for this MaterializationResponsibility.
+##
+
+proc orcMaterializationResponsibilityGetExecutionSession*(
+    MR: OrcMaterializationResponsibilityRef): OrcExecutionSessionRef {.
+    importc: "LLVMOrcMaterializationResponsibilityGetExecutionSession",
+    dynlib: LLVMLib.}
+## *
+##  Returns the symbol flags map for this responsibility instance.
+##
+##  The length of the array is returned in NumPairs and the caller is responsible
+##  for the returned memory and needs to call OrcDisposeCSymbolFlagsMap.
+##
+##  To use the returned symbols beyond the livetime of the
+##  MaterializationResponsibility requires the caller to retain the symbols
+##  explicitly.
+##
+
+proc orcMaterializationResponsibilityGetSymbols*(
+    MR: OrcMaterializationResponsibilityRef; NumPairs: ptr csize_t): OrcCSymbolFlagsMapPairs {.
+    importc: "LLVMOrcMaterializationResponsibilityGetSymbols", dynlib: LLVMLib.}
+## *
+##  Disposes of the passed OrcCSymbolFlagsMap.
+##
+##  Does not release the entries themselves.
+##
+
+proc orcDisposeCSymbolFlagsMap*(Pairs: OrcCSymbolFlagsMapPairs) {.
+    importc: "LLVMOrcDisposeCSymbolFlagsMap", dynlib: LLVMLib.}
+## *
+##  Returns the initialization pseudo-symbol, if any. This symbol will also
+##  be present in the SymbolFlagsMap for this MaterializationResponsibility
+##  object.
+##
+##  The returned symbol is not retained over any mutating operation of the
+##  MaterializationResponsbility or beyond the lifetime thereof.
+##
+
+proc orcMaterializationResponsibilityGetInitializerSymbol*(
+    MR: OrcMaterializationResponsibilityRef): OrcSymbolStringPoolEntryRef {.
+    importc: "LLVMOrcMaterializationResponsibilityGetInitializerSymbol",
+    dynlib: LLVMLib.}
+## *
+##  Returns the names of any symbols covered by this
+##  MaterializationResponsibility object that have queries pending. This
+##  information can be used to return responsibility for unrequested symbols
+##  back to the JITDylib via the delegate method.
+##
+
+proc orcMaterializationResponsibilityGetRequestedSymbols*(
+    MR: OrcMaterializationResponsibilityRef; NumSymbols: ptr csize_t): ptr OrcSymbolStringPoolEntryRef {.
+    importc: "LLVMOrcMaterializationResponsibilityGetRequestedSymbols",
+    dynlib: LLVMLib.}
+## *
+##  Disposes of the passed OrcSymbolStringPoolEntryRef* .
+##
+##  Does not release the symbols themselves.
+##
+
+proc orcDisposeSymbols*(Symbols: ptr OrcSymbolStringPoolEntryRef) {.
+    importc: "LLVMOrcDisposeSymbols", dynlib: LLVMLib.}
+##
+##  Notifies the target JITDylib that the given symbols have been resolved.
+##  This will update the given symbols' addresses in the JITDylib, and notify
+##  any pending queries on the given symbols of their resolution. The given
+##  symbols must be ones covered by this MaterializationResponsibility
+##  instance. Individual calls to this method may resolve a subset of the
+##  symbols, but all symbols must have been resolved prior to calling emit.
+##
+##  This method will return an error if any symbols being resolved have been
+##  moved to the error state due to the failure of a dependency. If this
+##  method returns an error then clients should log it and call
+##  OrcMaterializationResponsibilityFailMaterialization. If no dependencies
+##  have been registered for the symbols covered by this
+##  MaterializationResponsibiility then this method is guaranteed to return
+##  ErrorSuccess.
+##
+
+proc orcMaterializationResponsibilityNotifyResolved*(
+    MR: OrcMaterializationResponsibilityRef; Symbols: OrcCSymbolMapPairs;
+    NumPairs: csize_t): ErrorRef {.importc: "LLVMOrcMaterializationResponsibilityNotifyResolved",
+                                    dynlib: LLVMLib.}
+## *
+##  Notifies the target JITDylib (and any pending queries on that JITDylib)
+##  that all symbols covered by this MaterializationResponsibility instance
+##  have been emitted.
+##
+##  This method will return an error if any symbols being resolved have been
+##  moved to the error state due to the failure of a dependency. If this
+##  method returns an error then clients should log it and call
+##  OrcMaterializationResponsibilityFailMaterialization.
+##  If no dependencies have been registered for the symbols covered by this
+##  MaterializationResponsibiility then this method is guaranteed to return
+##  ErrorSuccess.
+##
+
+proc orcMaterializationResponsibilityNotifyEmitted*(
+    MR: OrcMaterializationResponsibilityRef): ErrorRef {.
+    importc: "LLVMOrcMaterializationResponsibilityNotifyEmitted", dynlib: LLVMLib.}
+## *
+##  Attempt to claim responsibility for new definitions. This method can be
+##  used to claim responsibility for symbols that are added to a
+##  materialization unit during the compilation process (e.g. literal pool
+##  symbols). Symbol linkage rules are the same as for symbols that are
+##  defined up front: duplicate strong definitions will result in errors.
+##  Duplicate weak definitions will be discarded (in which case they will
+##  not be added to this responsibility instance).
+##
+##  This method can be used by materialization units that want to add
+##  additional symbols at materialization time (e.g. stubs, compile
+##  callbacks, metadata)
+##
+
+proc orcMaterializationResponsibilityDefineMaterializing*(
+    MR: OrcMaterializationResponsibilityRef;
+    Pairs: OrcCSymbolFlagsMapPairs; NumPairs: csize_t): ErrorRef {.
+    importc: "LLVMOrcMaterializationResponsibilityDefineMaterializing",
+    dynlib: LLVMLib.}
+## *
+##  Notify all not-yet-emitted covered by this MaterializationResponsibility
+##  instance that an error has occurred.
+##  This will remove all symbols covered by this MaterializationResponsibilty
+##  from the target JITDylib, and send an error to any queries waiting on
+##  these symbols.
+##
+
+proc orcMaterializationResponsibilityFailMaterialization*(
+    MR: OrcMaterializationResponsibilityRef) {.
+    importc: "LLVMOrcMaterializationResponsibilityFailMaterialization",
+    dynlib: LLVMLib.}
+## *
+##  Transfers responsibility to the given MaterializationUnit for all
+##  symbols defined by that MaterializationUnit. This allows
+##  materializers to break up work based on run-time information (e.g.
+##  by introspecting which symbols have actually been looked up and
+##  materializing only those).
+##
+
+proc orcMaterializationResponsibilityReplace*(
+    MR: OrcMaterializationResponsibilityRef; MU: OrcMaterializationUnitRef): ErrorRef {.
+    importc: "LLVMOrcMaterializationResponsibilityReplace", dynlib: LLVMLib.}
+## *
+##  Delegates responsibility for the given symbols to the returned
+##  materialization responsibility. Useful for breaking up work between
+##  threads, or different kinds of materialization processes.
+##
+##  The caller retains responsibility of the the passed
+##  MaterializationResponsibility.
+##
+
+proc orcMaterializationResponsibilityDelegate*(
+    MR: OrcMaterializationResponsibilityRef;
+    Symbols: ptr OrcSymbolStringPoolEntryRef; NumSymbols: csize_t;
+    Result: ptr OrcMaterializationResponsibilityRef): ErrorRef {.
+    importc: "LLVMOrcMaterializationResponsibilityDelegate", dynlib: LLVMLib.}
+## *
+##  Adds dependencies to a symbol that the MaterializationResponsibility is
+##  responsible for.
+##
+##  This function takes ownership of Dependencies struct. The Names
+##  array have been retained for this function. This allows the following
+##  pattern...
+##
+##    OrcSymbolStringPoolEntryRef Names[] = {...};
+##    OrcCDependenceMapPair Dependence = {JD, {Names, sizeof(Names)}}
+##    OrcMaterializationResponsibilityAddDependencies(JD, Name, &Dependence,
+##  1);
+##
+##  ... without requiring cleanup of the elements of the Names array afterwards.
+##
+##  The client is still responsible for deleting the Dependencies.Names array
+##  itself.
+##
+
+proc orcMaterializationResponsibilityAddDependencies*(
+    MR: OrcMaterializationResponsibilityRef;
+    Name: OrcSymbolStringPoolEntryRef;
+    Dependencies: OrcCDependenceMapPairs; NumPairs: csize_t) {.
+    importc: "LLVMOrcMaterializationResponsibilityAddDependencies",
+    dynlib: LLVMLib.}
+## *
+##  Adds dependencies to all symbols that the MaterializationResponsibility is
+##  responsible for. See OrcMaterializationResponsibilityAddDependencies for
+##  notes about memory responsibility.
+##
+
+proc orcMaterializationResponsibilityAddDependenciesForAll*(
+    MR: OrcMaterializationResponsibilityRef;
+    Dependencies: OrcCDependenceMapPairs; NumPairs: csize_t) {.
+    importc: "LLVMOrcMaterializationResponsibilityAddDependenciesForAll",
+    dynlib: LLVMLib.}
+## *
+##  Create a "bare" JITDylib.
+##
+##  The client is responsible for ensuring that the JITDylib's name is unique,
+##  e.g. by calling OrcExecutionSessionGetJTIDylibByName first.
+##
+##  This call does not install any library code or symbols into the newly
+##  created JITDylib. The client is responsible for all configuration.
+##
+
+proc orcExecutionSessionCreateBareJITDylib*(ES: OrcExecutionSessionRef;
+    Name: cstring): OrcJITDylibRef {.importc: "LLVMOrcExecutionSessionCreateBareJITDylib",
+                                      dynlib: LLVMLib.}
+## *
+##  Create a JITDylib.
+##
+##  The client is responsible for ensuring that the JITDylib's name is unique,
+##  e.g. by calling OrcExecutionSessionGetJTIDylibByName first.
+##
+##  If a Platform is attached to the ExecutionSession then
+##  Platform::setupJITDylib will be called to install standard platform symbols
+##  (e.g. standard library interposes). If no Platform is installed then this
+##  call is equivalent to ExecutionSessionRefCreateBareJITDylib and will
+##  always return success.
+##
+
+proc orcExecutionSessionCreateJITDylib*(ES: OrcExecutionSessionRef;
+    Result: ptr OrcJITDylibRef; Name: cstring): ErrorRef {.
+    importc: "LLVMOrcExecutionSessionCreateJITDylib", dynlib: LLVMLib.}
+## *
+##  Returns the JITDylib with the given name, or NULL if no such JITDylib
+##  exists.
+##
+
+proc orcExecutionSessionGetJITDylibByName*(ES: OrcExecutionSessionRef;
+    Name: cstring): OrcJITDylibRef {.importc: "LLVMOrcExecutionSessionGetJITDylibByName",
+                                      dynlib: LLVMLib.}
+## *
+##  Return a reference to a newly created resource tracker associated with JD.
+##  The tracker is returned with an initial ref-count of 1, and must be released
+##  with OrcReleaseResourceTracker when no longer needed.
+##
+
+proc orcJITDylibCreateResourceTracker*(JD: OrcJITDylibRef): OrcResourceTrackerRef {.
+    importc: "LLVMOrcJITDylibCreateResourceTracker", dynlib: LLVMLib.}
+## *
+##  Return a reference to the default resource tracker for the given JITDylib.
+##  This operation will increase the retain count of the tracker: Clients should
+##  call OrcReleaseResourceTracker when the result is no longer needed.
+##
+
+proc orcJITDylibGetDefaultResourceTracker*(JD: OrcJITDylibRef): OrcResourceTrackerRef {.
+    importc: "LLVMOrcJITDylibGetDefaultResourceTracker", dynlib: LLVMLib.}
+## *
+##  Add the given MaterializationUnit to the given JITDylib.
+##
+##  If this operation succeeds then JITDylib JD will take ownership of MU.
+##  If the operation fails then ownership remains with the caller who should
+##  call OrcDisposeMaterializationUnit to destroy it.
+##
+
+proc orcJITDylibDefine*(JD: OrcJITDylibRef;
+                           MU: OrcMaterializationUnitRef): ErrorRef {.
+    importc: "LLVMOrcJITDylibDefine", dynlib: LLVMLib.}
+## *
+##  Calls remove on all trackers associated with this JITDylib, see
+##  JITDylib::clear().
+##
+
+proc orcJITDylibClear*(JD: OrcJITDylibRef): ErrorRef {.
+    importc: "LLVMOrcJITDylibClear", dynlib: LLVMLib.}
+## *
+##  Add a DefinitionGenerator to the given JITDylib.
+##
+##  The JITDylib will take ownership of the given generator: The client is no
+##  longer responsible for managing its memory.
+##
+
+proc orcJITDylibAddGenerator*(JD: OrcJITDylibRef;
+                                 DG: OrcDefinitionGeneratorRef) {.
+    importc: "LLVMOrcJITDylibAddGenerator", dynlib: LLVMLib.}
+## *
+##  Create a custom generator.
+##
+
+proc orcCreateCustomCAPIDefinitionGenerator*(
+    F: OrcCAPIDefinitionGeneratorTryToGenerateFunction; Ctx: pointer): OrcDefinitionGeneratorRef {.
+    importc: "LLVMOrcCreateCustomCAPIDefinitionGenerator", dynlib: LLVMLib.}
+## *
+##  Get a DynamicLibrarySearchGenerator that will reflect process symbols into
+##  the JITDylib. On success the resulting generator is owned by the client.
+##  Ownership is typically transferred by adding the instance to a JITDylib
+##  using OrcJITDylibAddGenerator,
+##
+##  The GlobalPrefix argument specifies the character that appears on the front
+##  of linker-mangled symbols for the target platform (e.g. '_' on MachO).
+##  If non-null, this character will be stripped from the start of all symbol
+##  strings before passing the remaining substring to dlsym.
+##
+##  The optional Filter and Ctx arguments can be used to supply a symbol name
+##  filter: Only symbols for which the filter returns true will be visible to
+##  JIT'd code. If the Filter argument is null then all process symbols will
+##  be visible to JIT'd code. Note that the symbol name passed to the Filter
+##  function is the full mangled symbol: The client is responsible for stripping
+##  the global prefix if present.
+##
+
+proc orcCreateDynamicLibrarySearchGeneratorForProcess*(
+    Result: ptr OrcDefinitionGeneratorRef; GlobalPrefx: char;
+    Filter: OrcSymbolPredicate; FilterCtx: pointer): ErrorRef {.
+    importc: "LLVMOrcCreateDynamicLibrarySearchGeneratorForProcess",
+    dynlib: LLVMLib.}
+## *
+##  Create a ThreadSafeContext containing a new Context.
+##
+##  Ownership of the underlying ThreadSafeContext data is shared: Clients
+##  can and should dispose of their ThreadSafeContext as soon as they no longer
+##  need to refer to it directly. Other references (e.g. from ThreadSafeModules)
+##  will keep the data alive as long as it is needed.
+##
+
+proc orcCreateNewThreadSafeContext*(): OrcThreadSafeContextRef {.
+    importc: "LLVMOrcCreateNewThreadSafeContext", dynlib: LLVMLib.}
+## *
+##  Get a reference to the wrapped Context.
+##
+
+proc orcThreadSafeContextGetContext*(TSCtx: OrcThreadSafeContextRef): ContextRef {.
+    importc: "LLVMOrcThreadSafeContextGetContext", dynlib: LLVMLib.}
+## *
+##  Dispose of a ThreadSafeContext.
+##
+
+proc orcDisposeThreadSafeContext*(TSCtx: OrcThreadSafeContextRef) {.
+    importc: "LLVMOrcDisposeThreadSafeContext", dynlib: LLVMLib.}
+## *
+##  Create a ThreadSafeModule wrapper around the given  module. This takes
+##  ownership of the M argument which should not be disposed of or referenced
+##  after this function returns.
+##
+##  Ownership of the ThreadSafeModule is unique: If it is transferred to the JIT
+##  (e.g. by OrcLLJITAddIRModule) then the client is no longer
+##  responsible for it. If it is not transferred to the JIT then the client
+##  should call OrcDisposeThreadSafeModule to dispose of it.
+##
+
+proc orcCreateNewThreadSafeModule*(M: ModuleRef;
+                                      TSCtx: OrcThreadSafeContextRef): OrcThreadSafeModuleRef {.
+    importc: "LLVMOrcCreateNewThreadSafeModule", dynlib: LLVMLib.}
+## *
+##  Dispose of a ThreadSafeModule. This should only be called if ownership has
+##  not been passed to LLJIT (e.g. because some error prevented the client from
+##  adding this to the JIT).
+##
+
+proc orcDisposeThreadSafeModule*(TSM: OrcThreadSafeModuleRef) {.
+    importc: "LLVMOrcDisposeThreadSafeModule", dynlib: LLVMLib.}
+## *
+##  Apply the given function to the module contained in this ThreadSafeModule.
+##
+
+proc orcThreadSafeModuleWithModuleDo*(TSM: OrcThreadSafeModuleRef;
+    F: OrcGenericIRModuleOperationFunction; Ctx: pointer): ErrorRef {.
+    importc: "LLVMOrcThreadSafeModuleWithModuleDo", dynlib: LLVMLib.}
+## *
+##  Create a JITTargetMachineBuilder by detecting the host.
+##
+##  On success the client owns the resulting JITTargetMachineBuilder. It must be
+##  passed to a consuming operation (e.g.
+##  OrcLLJITBuilderSetJITTargetMachineBuilder) or disposed of by calling
+##  OrcDisposeJITTargetMachineBuilder.
+##
+
+proc orcJITTargetMachineBuilderDetectHost*(
+    Result: ptr OrcJITTargetMachineBuilderRef): ErrorRef {.
+    importc: "LLVMOrcJITTargetMachineBuilderDetectHost", dynlib: LLVMLib.}
+## *
+##  Create a JITTargetMachineBuilder from the given TargetMachine template.
+##
+##  This operation takes ownership of the given TargetMachine and destroys it
+##  before returing. The resulting JITTargetMachineBuilder is owned by the client
+##  and must be passed to a consuming operation (e.g.
+##  OrcLLJITBuilderSetJITTargetMachineBuilder) or disposed of by calling
+##  OrcDisposeJITTargetMachineBuilder.
+##
+
+proc orcJITTargetMachineBuilderCreateFromTargetMachine*(
+    TM: TargetMachineRef): OrcJITTargetMachineBuilderRef {.
+    importc: "LLVMOrcJITTargetMachineBuilderCreateFromTargetMachine",
+    dynlib: LLVMLib.}
+## *
+##  Dispose of a JITTargetMachineBuilder.
+##
+
+proc orcDisposeJITTargetMachineBuilder*(
+    JTMB: OrcJITTargetMachineBuilderRef) {.
+    importc: "LLVMOrcDisposeJITTargetMachineBuilder", dynlib: LLVMLib.}
+## *
+##  Returns the target triple for the given JITTargetMachineBuilder as a string.
+##
+##  The caller owns the resulting string as must dispose of it by calling
+##  DisposeMessage
+##
+
+proc orcJITTargetMachineBuilderGetTargetTriple*(
+    JTMB: OrcJITTargetMachineBuilderRef): cstring {.
+    importc: "LLVMOrcJITTargetMachineBuilderGetTargetTriple", dynlib: LLVMLib.}
+## *
+##  Sets the target triple for the given JITTargetMachineBuilder to the given
+##  string.
+##
+
+proc orcJITTargetMachineBuilderSetTargetTriple*(
+    JTMB: OrcJITTargetMachineBuilderRef; TargetTriple: cstring) {.
+    importc: "LLVMOrcJITTargetMachineBuilderSetTargetTriple", dynlib: LLVMLib.}
+## *
+##  Add an object to an ObjectLayer to the given JITDylib.
+##
+##  Adds a buffer representing an object file to the given JITDylib using the
+##  given ObjectLayer instance. This operation transfers ownership of the buffer
+##  to the ObjectLayer instance. The buffer should not be disposed of or
+##  referenced once this function returns.
+##
+##  Resources associated with the given object will be tracked by the given
+##  JITDylib's default ResourceTracker.
+##
+
+proc orcObjectLayerAddObjectFile*(ObjLayer: OrcObjectLayerRef;
+                                     JD: OrcJITDylibRef;
+                                     ObjBuffer: MemoryBufferRef): ErrorRef {.
+    importc: "LLVMOrcObjectLayerAddObjectFile", dynlib: LLVMLib.}
+## *
+##  Add an object to an ObjectLayer using the given ResourceTracker.
+##
+##  Adds a buffer representing an object file to the given ResourceTracker's
+##  JITDylib using the given ObjectLayer instance. This operation transfers
+##  ownership of the buffer to the ObjectLayer instance. The buffer should not
+##  be disposed of or referenced once this function returns.
+##
+##  Resources associated with the given object will be tracked by
+##  ResourceTracker RT.
+##
+
+proc orcObjectLayerAddObjectFileWithRT*(ObjLayer: OrcObjectLayerRef;
+    RT: OrcResourceTrackerRef; ObjBuffer: MemoryBufferRef): ErrorRef {.
+    importc: "LLVMOrcObjectLayerAddObjectFileWithRT", dynlib: LLVMLib.}
+## *
+##  Emit an object buffer to an ObjectLayer.
+##
+##  Ownership of the responsibility object and object buffer pass to this
+##  function. The client is not responsible for cleanup.
+##
+
+proc orcObjectLayerEmit*(ObjLayer: OrcObjectLayerRef;
+                            R: OrcMaterializationResponsibilityRef;
+                            ObjBuffer: MemoryBufferRef) {.
+    importc: "LLVMOrcObjectLayerEmit", dynlib: LLVMLib.}
+## *
+##  Dispose of an ObjectLayer.
+##
+
+proc orcDisposeObjectLayer*(ObjLayer: OrcObjectLayerRef) {.
+    importc: "LLVMOrcDisposeObjectLayer", dynlib: LLVMLib.}
+proc orcIRTransformLayerEmit*(IRTransformLayer: OrcIRTransformLayerRef;
+                                 MR: OrcMaterializationResponsibilityRef;
+                                 TSM: OrcThreadSafeModuleRef) {.
+    importc: "LLVMOrcIRTransformLayerEmit", dynlib: LLVMLib.}
+## *
+##  Set the transform function of the provided transform layer, passing through a
+##  pointer to user provided context.
+##
+
+proc orcIRTransformLayerSetTransform*(
+    IRTransformLayer: OrcIRTransformLayerRef;
+    TransformFunction: OrcIRTransformLayerTransformFunction; Ctx: pointer) {.
+    importc: "LLVMOrcIRTransformLayerSetTransform", dynlib: LLVMLib.}
+## *
+##  Set the transform function on an OrcObjectTransformLayer.
+##
+
+proc orcObjectTransformLayerSetTransform*(
+    ObjTransformLayer: OrcObjectTransformLayerRef;
+    TransformFunction: OrcObjectTransformLayerTransformFunction; Ctx: pointer) {.
+    importc: "LLVMOrcObjectTransformLayerSetTransform", dynlib: LLVMLib.}
+## *
+##  Create a LocalIndirectStubsManager from the given target triple.
+##
+##  The resulting IndirectStubsManager is owned by the client
+##  and must be disposed of by calling OrcDisposeDisposeIndirectStubsManager.
+##
+
+proc orcCreateLocalIndirectStubsManager*(TargetTriple: cstring): OrcIndirectStubsManagerRef {.
+    importc: "LLVMOrcCreateLocalIndirectStubsManager", dynlib: LLVMLib.}
+## *
+##  Dispose of an IndirectStubsManager.
+##
+
+proc orcDisposeIndirectStubsManager*(ISM: OrcIndirectStubsManagerRef) {.
+    importc: "LLVMOrcDisposeIndirectStubsManager", dynlib: LLVMLib.}
+proc orcCreateLocalLazyCallThroughManager*(TargetTriple: cstring;
+    ES: OrcExecutionSessionRef; ErrorHandlerAddr: OrcJITTargetAddress;
+    LCTM: ptr OrcLazyCallThroughManagerRef): ErrorRef {.
+    importc: "LLVMOrcCreateLocalLazyCallThroughManager", dynlib: LLVMLib.}
+## *
+##  Dispose of an LazyCallThroughManager.
+##
+
+proc orcDisposeLazyCallThroughManager*(LCTM: OrcLazyCallThroughManagerRef) {.
+    importc: "LLVMOrcDisposeLazyCallThroughManager", dynlib: LLVMLib.}
+## *
+##  Create a DumpObjects instance.
+##
+##  DumpDir specifies the path to write dumped objects to. DumpDir may be empty
+##  in which case files will be dumped to the working directory.
+##
+##  IdentifierOverride specifies a file name stem to use when dumping objects.
+##  If empty then each MemoryBuffer's identifier will be used (with a .o suffix
+##  added if not already present). If an identifier override is supplied it will
+##  be used instead, along with an incrementing counter (since all buffers will
+##  use the same identifier, the resulting files will be named <ident>.o,
+##  <ident>.2.o, <ident>.3.o, and so on). IdentifierOverride should not contain
+##  an extension, as a .o suffix will be added by DumpObjects.
+##
+
+proc orcCreateDumpObjects*(DumpDir: cstring; IdentifierOverride: cstring): OrcDumpObjectsRef {.
+    importc: "LLVMOrcCreateDumpObjects", dynlib: LLVMLib.}
+## *
+##  Dispose of a DumpObjects instance.
+##
+
+proc orcDisposeDumpObjects*(DumpObjects: OrcDumpObjectsRef) {.
+    importc: "LLVMOrcDisposeDumpObjects", dynlib: LLVMLib.}
+## *
+##  Dump the contents of the given MemoryBuffer.
+##
+
+proc orcDumpObjects_CallOperator*(DumpObjects: OrcDumpObjectsRef;
+                                     ObjBuffer: ptr MemoryBufferRef): ErrorRef {.
+    importc: "LLVMOrcDumpObjects_CallOperator", dynlib: LLVMLib.}
+##  _C_EXTERN_C_END

--- a/llvm/llvm/OrcBindings.nim
+++ b/llvm/llvm/OrcBindings.nim
@@ -1,0 +1,165 @@
+## ===----------- llvm-c/OrcBindings.h - Orc Lib C Iface ---------*- C++ -*-===*\
+## |*                                                                            *|
+## |* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+## |* Exceptions.                                                                *|
+## |* See https://llvm.org/LICENSE.txt for license information.                  *|
+## |* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+## |*                                                                            *|
+## |*===----------------------------------------------------------------------===*|
+## |*                                                                            *|
+## |* This header declares the C interface to libLLVMOrcJIT.a, which implements  *|
+## |* JIT compilation of LLVM IR.                                                *|
+## |*                                                                            *|
+## |* Many exotic languages can interoperate with C code but have a harder time  *|
+## |* with C++ due to name mangling. So in addition to C, this interface enables *|
+## |* tools written in such languages.                                           *|
+## |*                                                                            *|
+## |* Note: This interface is experimental. It is *NOT* stable, and may be       *|
+## |*       changed without warning.                                             *|
+## |*                                                                            *|
+## \*===----------------------------------------------------------------------===
+
+type
+  OrcJITStackRef* = ptr orcOpaqueJITStack
+  OrcModuleHandle* = uint64
+  OrcTargetAddress* = uint64
+  OrcSymbolResolverFn* = proc (name: cstring; lookupCtx: pointer): uint64 {.cdecl.}
+  OrcLazyCompileCallbackFn* = proc (jITStack: OrcJITStackRef; callbackCtx: pointer): uint64 {.cdecl.}
+
+## *
+##  Create an ORC JIT stack.
+##
+##  The client owns the resulting stack, and must call OrcDisposeInstance(...)
+##  to destroy it and free its memory. The JIT stack will take ownership of the
+##  TargetMachine, which will be destroyed when the stack is destroyed. The
+##  client should not attempt to dispose of the Target Machine, or it will result
+##  in a double-free.
+##
+
+proc orcCreateInstance*(tm: TargetMachineRef): OrcJITStackRef {.
+    importc: "LLVMOrcCreateInstance", dynlib: LLVMLib.}
+## *
+##  Get the error message for the most recent error (if any).
+##
+##  This message is owned by the ORC JIT Stack and will be freed when the stack
+##  is disposed of by LLVMOrcDisposeInstance.
+##
+
+proc orcGetErrorMsg*(jITStack: OrcJITStackRef): cstring {.
+    importc: "LLVMOrcGetErrorMsg", dynlib: LLVMLib.}
+## *
+##  Mangle the given symbol.
+##  Memory will be allocated for MangledSymbol to hold the result. The client
+##
+
+proc orcGetMangledSymbol*(jITStack: OrcJITStackRef; mangledSymbol: cstringArray;
+                         symbol: cstring) {.importc: "LLVMOrcGetMangledSymbol",
+    dynlib: LLVMLib.}
+## *
+##  Dispose of a mangled symbol.
+##
+
+proc orcDisposeMangledSymbol*(mangledSymbol: cstring) {.
+    importc: "LLVMOrcDisposeMangledSymbol", dynlib: LLVMLib.}
+## *
+##  Create a lazy compile callback.
+##
+
+proc orcCreateLazyCompileCallback*(jITStack: OrcJITStackRef;
+                                  retAddr: ptr OrcTargetAddress;
+                                  callback: OrcLazyCompileCallbackFn;
+                                  callbackCtx: pointer): ErrorRef {.
+    importc: "LLVMOrcCreateLazyCompileCallback", dynlib: LLVMLib.}
+## *
+##  Create a named indirect call stub.
+##
+
+proc orcCreateIndirectStub*(jITStack: OrcJITStackRef; stubName: cstring;
+                           initAddr: OrcTargetAddress): ErrorRef {.
+    importc: "LLVMOrcCreateIndirectStub", dynlib: LLVMLib.}
+## *
+##  Set the pointer for the given indirect stub.
+##
+
+proc orcSetIndirectStubPointer*(jITStack: OrcJITStackRef; stubName: cstring;
+                               newAddr: OrcTargetAddress): ErrorRef {.
+    importc: "LLVMOrcSetIndirectStubPointer", dynlib: LLVMLib.}
+## *
+##  Add module to be eagerly compiled.
+##
+
+proc orcAddEagerlyCompiledIR*(jITStack: OrcJITStackRef;
+                             retHandle: ptr OrcModuleHandle; `mod`: ModuleRef;
+                             symbolResolver: OrcSymbolResolverFn;
+                             symbolResolverCtx: pointer): ErrorRef {.
+    importc: "LLVMOrcAddEagerlyCompiledIR", dynlib: LLVMLib.}
+## *
+##  Add module to be lazily compiled one function at a time.
+##
+
+proc orcAddLazilyCompiledIR*(jITStack: OrcJITStackRef;
+                            retHandle: ptr OrcModuleHandle; `mod`: ModuleRef;
+                            symbolResolver: OrcSymbolResolverFn;
+                            symbolResolverCtx: pointer): ErrorRef {.
+    importc: "LLVMOrcAddLazilyCompiledIR", dynlib: LLVMLib.}
+## *
+##  Add an object file.
+##
+##  This method takes ownership of the given memory buffer and attempts to add
+##  it to the JIT as an object file.
+##  Clients should *not* dispose of the 'Obj' argument: the JIT will manage it
+##  from this call onwards.
+##
+
+proc orcAddObjectFile*(jITStack: OrcJITStackRef; retHandle: ptr OrcModuleHandle;
+                      obj: MemoryBufferRef; symbolResolver: OrcSymbolResolverFn;
+                      symbolResolverCtx: pointer): ErrorRef {.
+    importc: "LLVMOrcAddObjectFile", dynlib: LLVMLib.}
+## *
+##  Remove a module set from the JIT.
+##
+##  This works for all modules that can be added via OrcAdd*, including object
+##  files.
+##
+
+proc orcRemoveModule*(jITStack: OrcJITStackRef; h: OrcModuleHandle): ErrorRef {.
+    importc: "LLVMOrcRemoveModule", dynlib: LLVMLib.}
+## *
+##  Get symbol address from JIT instance.
+##
+
+proc orcGetSymbolAddress*(jITStack: OrcJITStackRef; retAddr: ptr OrcTargetAddress;
+                         symbolName: cstring): ErrorRef {.
+    importc: "LLVMOrcGetSymbolAddress", dynlib: LLVMLib.}
+## *
+##  Get symbol address from JIT instance, searching only the specified
+##  handle.
+##
+
+proc orcGetSymbolAddressIn*(jITStack: OrcJITStackRef;
+                           retAddr: ptr OrcTargetAddress; h: OrcModuleHandle;
+                           symbolName: cstring): ErrorRef {.
+    importc: "LLVMOrcGetSymbolAddressIn", dynlib: LLVMLib.}
+## *
+##  Dispose of an ORC JIT stack.
+##
+
+proc orcDisposeInstance*(jITStack: OrcJITStackRef): ErrorRef {.
+    importc: "LLVMOrcDisposeInstance", dynlib: LLVMLib.}
+## *
+##  Register a JIT Event Listener.
+##
+##  A NULL listener is ignored.
+##
+
+proc orcRegisterJITEventListener*(jITStack: OrcJITStackRef; L: JITEventListenerRef) {.
+    importc: "LLVMOrcRegisterJITEventListener", dynlib: LLVMLib.}
+## *
+##  Unegister a JIT Event Listener.
+##
+##  A NULL listener is ignored.
+##
+
+proc orcUnregisterJITEventListener*(jITStack: OrcJITStackRef;
+                                   L: JITEventListenerRef) {.
+    importc: "LLVMOrcUnregisterJITEventListener", dynlib: LLVMLib.}

--- a/llvm/llvm/OrcEE.nim
+++ b/llvm/llvm/OrcEE.nim
@@ -1,0 +1,48 @@
+## ===-- llvm-c/OrcEE.h - OrcV2 C bindings ExecutionEngine utils -*- C++ -*-===*\
+## |*                                                                            *|
+## |* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+## |* Exceptions.                                                                *|
+## |* See https://llvm.org/LICENSE.txt for license information.                  *|
+## |* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+## |*                                                                            *|
+## |*===----------------------------------------------------------------------===*|
+## |*                                                                            *|
+## |* This header declares the C interface to ExecutionEngine based utils, e.g.  *|
+## |* RTDyldObjectLinkingLayer (based on RuntimeDyld) in Orc.                    *|
+## |*                                                                            *|
+## |* Many exotic languages can interoperate with C code but have a harder time  *|
+## |* with C++ due to name mangling. So in addition to C, this interface enables *|
+## |* tools written in such languages.                                           *|
+## |*                                                                            *|
+## |* Note: This interface is experimental. It is *NOT* stable, and may be       *|
+## |*       changed without warning. Only C API usage documentation is           *|
+## |*       provided. See the C++ documentation for all higher level ORC API     *|
+## |*       details.                                                             *|
+## |*                                                                            *|
+## \*===----------------------------------------------------------------------===
+
+#import
+#  Error, ExecutionEngine, Orc, TargetMachine, Types
+
+##  LLVM_C_EXTERN_C_BEGIN
+## *
+##  Create a RTDyldObjectLinkingLayer instance using the standard
+##  SectionMemoryManager for memory management.
+##
+
+proc orcCreateRTDyldObjectLinkingLayerWithSectionMemoryManager*(
+    ES: OrcExecutionSessionRef): OrcObjectLayerRef {.
+    importc: "LLVMOrcCreateRTDyldObjectLinkingLayerWithSectionMemoryManager",
+    dynlib: LLVMLib.}
+## *
+##  Add the given listener to the given RTDyldObjectLinkingLayer.
+##
+##  Note: Layer must be an RTDyldObjectLinkingLayer instance or
+##  behavior is undefined.
+##
+
+proc orcRTDyldObjectLinkingLayerRegisterJITEventListener*(
+    RTDyldObjLinkingLayer: OrcObjectLayerRef;
+    Listener: JITEventListenerRef) {.importc: "LLVMOrcRTDyldObjectLinkingLayerRegisterJITEventListener",
+                                       dynlib: LLVMLib.}
+##  LLVM_C_EXTERN_C_END

--- a/llvm/rebuild.sh
+++ b/llvm/rebuild.sh
@@ -4,7 +4,7 @@ LLVM_INC=../ext/llvm-13.0.0.src/include
 C2NIM="../../c2nim/c2nim"
 C2NIMFLAGS="--nep1 --skipinclude --prefix:LLVM --dynlib:LLVMLib"
 
-HEADERS="BitReader.h BitWriter.h Core.h Error.h DebugInfo.h IRReader.h Linker.h Target.h TargetMachine.h Support.h Types.h Transforms/PassManagerBuilder.h"
+HEADERS="BitReader.h BitWriter.h Core.h Error.h DebugInfo.h IRReader.h Linker.h OrcBindings.h Target.h TargetMachine.h Support.h Types.h Transforms/PassManagerBuilder.h"
 
 for a in $HEADERS; do
   OUT="llvm/${a%.h}.nim"

--- a/llvm/rebuild.sh
+++ b/llvm/rebuild.sh
@@ -4,7 +4,7 @@ LLVM_INC=../ext/llvm-13.0.0.src/include
 C2NIM="../../c2nim/c2nim"
 C2NIMFLAGS="--nep1 --skipinclude --prefix:LLVM --dynlib:LLVMLib"
 
-HEADERS="BitReader.h BitWriter.h Core.h Error.h DebugInfo.h IRReader.h Linker.h OrcBindings.h Target.h TargetMachine.h Support.h Types.h Transforms/PassManagerBuilder.h"
+HEADERS="BitReader.h BitWriter.h Core.h Error.h ExecutionEngine.h DebugInfo.h IRReader.h Linker.h LLJIT.h Orc.h OrcEE.h Target.h TargetMachine.h Support.h Types.h Transforms/PassManagerBuilder.h"
 
 for a in $HEADERS; do
   OUT="llvm/${a%.h}.nim"

--- a/nlvm/llgen.nim
+++ b/nlvm/llgen.nim
@@ -42,6 +42,7 @@ import
   llvm/llvm,
 
   lllink,
+  lljit,
   llplatform
 
 type
@@ -166,6 +167,9 @@ type
     # Exception handling
     personalityFn: llvm.ValueRef
     landingPadTy: llvm.TypeRef
+
+    # Running
+    runCtx: RunContext
 
   LLValue = object
     v: llvm.ValueRef
@@ -2447,6 +2451,11 @@ proc genLocal(g: LLGen, n: PNode): LLValue =
   g.symbols[s.id] = lv
   lv
 
+proc initToType(g: LLGen, v: var seq[byte], t: llvm.TypeRef) =
+  let sz = g.debugSize(t)
+  if v.len() != sz.storeBits.int div 8:
+    v.setLen(sz.storeBits.int div 8)
+
 proc genGlobal(g: LLGen, n: PNode, isConst: bool): LLValue =
   let s = n.sym
   if s.id in g.symbols:
@@ -2485,6 +2494,9 @@ proc genGlobal(g: LLGen, n: PNode, isConst: bool): LLValue =
 
   result = LLValue(v: v, lode: n, storage: s.loc.storage)
   g.symbols[s.id] = result
+
+  if optWasNimscript in g.config.globalOptions:
+    g.initToType(g.runCtx.store.mgetOrPut(s.llName, @[]), v.typeOfX())
 
 proc getUnreachableBlock(g: LLGen): llvm.BasicBlockRef =
   if g.f.unreachableBlock == nil:
@@ -7406,18 +7418,18 @@ proc myClose(graph: ModuleGraph, b: PPassContext, n: PNode): PNode =
 
       g.finalize()
 
-  if g.d != nil:
-    g.d.dIBuilderFinalize()
-
   g.loadBase()
 
-  g.writeOutput(changeFileExt(g.config.projectFull, "").string)
-
   if g.d != nil:
+    g.d.dIBuilderFinalize()
     g.d.disposeDIBuilder()
     g.d = nil
 
-  g.m.disposeModule()
+  if optWasNimscript in g.config.globalOptions:
+    runModule(g.config, g.runCtx, g.tm, g.m)
+  else:
+    g.writeOutput(changeFileExt(g.config.projectFull, "").string)
+    g.m.disposeModule()
 
   n
 

--- a/nlvm/llgen.nim
+++ b/nlvm/llgen.nim
@@ -7021,6 +7021,8 @@ proc genNode(g: LLGen, n: PNode, load: bool, tgt: LLValue): LLValue =
   of nkTypeSection, nkCommentStmt, nkIteratorDef, nkIncludeStmt,
      nkImportStmt, nkImportExceptStmt, nkExportStmt, nkExportExceptStmt,
      nkFromStmt, nkTemplateDef, nkMacroDef: discard
+  # of nkAsmStmt: # inline assembly, see: https://llvm.org/doxygen/classllvm_1_1InlineAsm.html
+  # of nkParForStmt: # openmp `||` operator, see: https://clang.llvm.org/doxygen/classclang_1_1OMPParallelForDirective.html
   else:
     g.config.internalError(n.info, "Unhandled node: " & $n)
 

--- a/nlvm/lljit.nim
+++ b/nlvm/lljit.nim
@@ -1,0 +1,49 @@
+# Run LLVM module using ORC jit
+
+import
+  tables, posix,
+
+  compiler/[options, msgs],
+  llvm/llvm
+
+type
+  RunContext* = object
+    self: pointer ## Handle to main executable, used for symbol lookups
+    store*: Table[string, seq[byte]]     ## Memory for global variables
+
+proc orcResolver(name: cstring, lookupCtx: pointer): uint64 {.cdecl.} =
+  let
+    runCtx = cast[ptr RunContext](lookupCtx)
+    name = $name
+
+  if name in runCtx.store:
+    cast[uint64](runCtx.store[name][0].addr)
+  else:
+    # TODO collect libraries that should be linked to and include them in the
+    #      lookup instead of looking up in current executable
+    cast[uint64](dlsym(runCtx.self, name))
+
+proc runModule*(
+    config: ConfigRef,
+    ctx: var RunContext,
+    tm: llvm.TargetMachineRef,
+    m: llvm.ModuleRef) =
+  let orc = orcCreateInstance(tm)
+
+  ctx.self = dlopen(nil, 0)
+
+  block:
+    var om: OrcModuleHandle
+    let err = orcAddEagerlyCompiledIR(
+      orc, addr om, m, orcResolver, addr ctx)
+    if not err.isNil:
+      config.internalError($err.getErrorMessage)
+
+  block:
+    var main: OrcTargetAddress
+    let err = orcGetSymbolAddress(orc, addr main, "main")
+
+    if not err.isNil:
+      config.internalError($err.getErrorMessage)
+
+    cast[proc() {.cdecl.}](main)()

--- a/nlvm/nlvm.nim
+++ b/nlvm/nlvm.nim
@@ -161,7 +161,13 @@ proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
       else:
         processSwitch(pass, p, config)
     of cmdArgument:
-      if processArgument(pass, p, argsCount, config): break
+      if argsCount == 0 and p.key.endsWith(".nim"):
+        config.command = "e"
+        incl(config.globalOptions, optWasNimscript)
+        config.projectName = unixToNativePath(p.key)
+        config.arguments = cmdLineRest(p)
+        break
+      elif processArgument(pass, p, argsCount, config): break
   if pass == passCmd2:
     if optRun notin config.globalOptions and config.arguments.len > 0 and config.command.normalize != "run":
       rawMessage(config, errGenerated, errArgsNeedRunOption)
@@ -243,6 +249,26 @@ proc mainCommand*(graph: ModuleGraph) =
   of "check":
     conf.cmd = cmdCheck
     commandCheck(graph)
+
+  of "e":
+    if not fileExists(conf.projectFull):
+      rawMessage(conf, errGenerated, "file does not exist: " & conf.projectFull.string)
+    elif conf.projectFull.string.endsWith(".nim"):
+      conf.cmd = cmdRun
+
+      # TODO: gc unsupported as of yet
+      conf.selectedGC = gcNone
+      conf.verbosity = 0
+      conf.notes = NotesVerbosity[0]
+
+      defineSymbol(conf.symbols, "nogc")
+      defineSymbol(conf.symbols, "useMalloc")
+
+
+      incl conf.globalOptions, optWasNimscript
+      commandCompile(graph)
+    elif not conf.projectFull.string.endsWith(".nims"):
+      rawMessage(conf, errGenerated, "not a NimScript file: " & conf.projectFull.string)
 
   else: conf.rawMessage(errGenerated, conf.command)
 


### PR DESCRIPTION
Hey!

I've been curious about playing around with nlvm and in particular your JIT branch ever since you opened that PR. Took a while... Thanks a lot for this project for sure!

Finally, looked into this and I stumbled pretty hard initially. Couldn't get the LLVM 9 branch to work (later figured out I just had to apply this patch:
https://www.mail-archive.com/commits@kudu.apache.org/msg08412.html
) and learned that the API used on that branch isn't available on LLVM 13 anymore. So I decided to try to wrap the new API and managed to get it to work over the weekend. :partying_face: 

So far the code is essentially achieving the same as in #18. I started from a rebase of that branch onto the current master.

I commented a bit more than usual on the `lljit.nim` code, as it was a bit hard to figure out. The documentation of the current C API is sorely lacking still. Most helpful were the examples (ORCv2C in here https://github.com/llvm/llvm-project/tree/main/llvm/examples/OrcV2Examples). In particular assigning a "search generator" for the symbols in the host process was hard to figure out.

I'm opening this PR especially to ask for a bit of guidance. Locally I'm playing around with an attempt to somehow JIT smaller Nim snippets (without having to recompile system etc. each time). For now I'm very much confused about how to best structure such code though. I have some ideas, but you probably thought about this already and have a much better understanding of what's going on in the compiler. So any input would be greatly appreciated!