### PR TITLE
Use built-in linker for executables

### DIFF
--- a/llvm/llvm.nim
+++ b/llvm/llvm.nim
@@ -128,9 +128,20 @@ type
   TargetMachineRef* = ptr OpaqueTargetMachine
   PassManagerBuilderRef* = ptr OpaquePassManagerBuilder
 
+  ComdatSelectionKind* {.size: sizeof(cint).} = enum
+    AnyComdatSelectionKind,        ## The linker may choose any COMDAT.
+    ExactMatchComdatSelectionKind, ## The data referenced by the COMDAT must
+                                      ## be the same.
+    LargestComdatSelectionKind,    ## The linker will choose the largest
+                                      ## COMDAT.
+    NoDeduplicateComdatSelectionKind, ## No deduplication is performed.
+    SameSizeComdatSelectionKind ## The data referenced by the COMDAT must be
+                                    ## the same size.
+
 include llvm/Types
 include llvm/Support
 
+include llvm/Comdat
 include llvm/Core
 include llvm/DebugInfo
 include llvm/BitReader
@@ -272,6 +283,13 @@ proc nimLLDLinkWasm*(args: openArray[string]): bool =
   defer: deallocCStringArray(argv)
 
   nimLLDLinkWasm(argv, args.len.csize_t)
+
+
+proc nimCreateTargetMachine*(t: TargetRef; triple: cstring; cpu: cstring;
+                         features: cstring; level: CodeGenOptLevel;
+                         reloc: RelocMode; codeModel: CodeModel): TargetMachineRef {.
+    importc: "LLVMNimCreateTargetMachine".}
+
 
 # A few helpers to make things more smooth
 

--- a/llvm/llvm/Comdat.nim
+++ b/llvm/llvm/Comdat.nim
@@ -1,0 +1,69 @@
+## ===-- llvm-c/Comdat.h - Module Comdat C Interface -------------*- C++ -*-===*\
+## |*                                                                            *|
+## |* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+## |* Exceptions.                                                                *|
+## |* See https://llvm.org/LICENSE.txt for license information.                  *|
+## |* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+## |*                                                                            *|
+## |*===----------------------------------------------------------------------===*|
+## |*                                                                            *|
+## |* This file defines the C interface to COMDAT.                               *|
+## |*                                                                            *|
+## \*===----------------------------------------------------------------------===
+
+## !!!Ignored construct:  # LLVM_C_COMDAT_H [NewLine] # LLVM_C_COMDAT_H [NewLine] # llvm-c/ExternC.h [NewLine] # llvm-c/Types.h [NewLine] LLVM_C_EXTERN_C_BEGIN *
+##  @defgroup LLVMCCoreComdat Comdats
+##  @ingroup LLVMCCore
+##
+##  @{
+##  typedef enum { LLVMAnyComdatSelectionKind , /< The linker may choose any COMDAT. LLVMExactMatchComdatSelectionKind , /< The data referenced by the COMDAT must
+## /< be the same. LLVMLargestComdatSelectionKind , /< The linker will choose the largest
+## /< COMDAT. LLVMNoDeduplicateComdatSelectionKind , /< No deduplication is performed. LLVMSameSizeComdatSelectionKind /< The data referenced by the COMDAT must be
+## /< the same size. } LLVMComdatSelectionKind ;
+## Error: expected ';'!!!
+
+## *
+##  Return the Comdat in the module with the specified name. It is created
+##  if it didn't already exist.
+##
+##  @see llvm::Module::getOrInsertComdat()
+##
+
+proc getOrInsertComdat*(m: ModuleRef; name: cstring): ComdatRef {.
+    importc: "LLVMGetOrInsertComdat", dynlib: LLVMLib.}
+## *
+##  Get the Comdat assigned to the given global object.
+##
+##  @see llvm::GlobalObject::getComdat()
+##
+
+proc getComdat*(v: ValueRef): ComdatRef {.importc: "LLVMGetComdat", dynlib: LLVMLib.}
+## *
+##  Assign the Comdat to the given global object.
+##
+##  @see llvm::GlobalObject::setComdat()
+##
+
+proc setComdat*(v: ValueRef; c: ComdatRef) {.importc: "LLVMSetComdat", dynlib: LLVMLib.}
+##
+##  Get the conflict resolution selection kind for the Comdat.
+##
+##  @see llvm::Comdat::getSelectionKind()
+##
+
+proc getComdatSelectionKind*(c: ComdatRef): ComdatSelectionKind {.
+    importc: "LLVMGetComdatSelectionKind", dynlib: LLVMLib.}
+##
+##  Set the conflict resolution selection kind for the Comdat.
+##
+##  @see llvm::Comdat::setSelectionKind()
+##
+
+proc setComdatSelectionKind*(c: ComdatRef; kind: ComdatSelectionKind) {.
+    importc: "LLVMSetComdatSelectionKind", dynlib: LLVMLib.}
+## *
+##  @}
+##
+
+## !!!Ignored construct:  LLVM_C_EXTERN_C_END # [NewLine]
+## Error: expected ';'!!!

--- a/llvm/rebuild.sh
+++ b/llvm/rebuild.sh
@@ -3,7 +3,7 @@ LLVM_INC=../ext/llvm-15.0.6.src/include
 C2NIM="../../c2nim/c2nim"
 C2NIMFLAGS="--nep1 --skipinclude --prefix:LLVM --dynlib:LLVMLib"
 
-HEADERS="BitReader.h BitWriter.h Core.h Error.h DebugInfo.h IRReader.h Linker.h Target.h TargetMachine.h Support.h Types.h Transforms/PassManagerBuilder.h"
+HEADERS="BitReader.h BitWriter.h Comdat.h Core.h Error.h DebugInfo.h IRReader.h Linker.h Target.h TargetMachine.h Support.h Types.h Transforms/PassManagerBuilder.h"
 
 for a in $HEADERS; do
   OUT="llvm/${a%.h}.nim"

--- a/llvm/wrapper.cc
+++ b/llvm/wrapper.cc
@@ -3,10 +3,16 @@
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/Module.h"
 
+#include "llvm/CodeGen/CommandFlags.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Target/CodeGenCWrappers.h"
+#include "llvm/Target/TargetMachine.h"
+
 #include "lld/Common/Driver.h"
 
 #include "llvm-c/Types.h"
 #include "llvm-c/Core.h"
+#include "llvm-c/TargetMachine.h"
 
 using namespace llvm;
 
@@ -52,4 +58,70 @@ extern "C" bool LLVMNimLLDLinkElf(const char **args, size_t arg_count) {
 extern "C" bool LLVMNimLLDLinkWasm(const char **args, size_t arg_count) {
   ArrayRef<const char *> array_ref_args(args, arg_count);
   return lld::wasm::link(array_ref_args, llvm::outs(), llvm::errs(), false, false);
+}
+
+static codegen::RegisterCodeGenFlags CGF;
+
+static Target *unwrap(LLVMTargetRef P) {
+  return reinterpret_cast<Target*>(P);
+}
+static LLVMTargetMachineRef wrap(const TargetMachine *P) {
+  return reinterpret_cast<LLVMTargetMachineRef>(const_cast<TargetMachine *>(P));
+}
+
+extern "C" LLVMTargetMachineRef LLVMNimCreateTargetMachine(LLVMTargetRef T,
+        const char *TT, const char *CPU, const char *Features,
+        LLVMCodeGenOptLevel Level, LLVMRelocMode Reloc,
+        LLVMCodeModel CodeModel) {
+  // This function is needed to register and use the common codegen flags -
+  // in particular when using lld which doesn't support mixed `.ctors` and
+  // `.init_array` sections and is made to work by using `.init_array`
+  // alone
+
+  Optional<Reloc::Model> RM;
+  switch (Reloc){
+    case LLVMRelocStatic:
+      RM = Reloc::Static;
+      break;
+    case LLVMRelocPIC:
+      RM = Reloc::PIC_;
+      break;
+    case LLVMRelocDynamicNoPic:
+      RM = Reloc::DynamicNoPIC;
+      break;
+    case LLVMRelocROPI:
+      RM = Reloc::ROPI;
+      break;
+    case LLVMRelocRWPI:
+      RM = Reloc::RWPI;
+      break;
+    case LLVMRelocROPI_RWPI:
+      RM = Reloc::ROPI_RWPI;
+      break;
+    default:
+      break;
+  }
+
+  bool JIT;
+  Optional<CodeModel::Model> CM = unwrap(CodeModel, JIT);
+
+  CodeGenOpt::Level OL;
+  switch (Level) {
+    case LLVMCodeGenLevelNone:
+      OL = CodeGenOpt::None;
+      break;
+    case LLVMCodeGenLevelLess:
+      OL = CodeGenOpt::Less;
+      break;
+    case LLVMCodeGenLevelAggressive:
+      OL = CodeGenOpt::Aggressive;
+      break;
+    default:
+      OL = CodeGenOpt::Default;
+      break;
+  }
+
+  TargetOptions opt = codegen::InitTargetOptionsFromCodeGenFlags(Triple(TT));
+  return wrap(unwrap(T)->createTargetMachine(TT, CPU, Features, opt, RM, CM,
+                                             OL, JIT));
 }

--- a/nlvm/lllink.nim
+++ b/nlvm/lllink.nim
@@ -13,65 +13,168 @@ import
   ],
   llvm/llvm
 
-proc stripLinkOption(s: string): string =
-  # TODO the gcc driver has multiple ways of passing stuff, and then there's the
-  #      shell to contend with, with its quoting etc.. this needs a better
-  #      approach
-  let tmp =
-    if s.startsWith("-Wl,"):
-      s[4..^1]
-    else:
-      s
-
-  strip(tmp, chars={'\''})
-
-proc stripLinkOption(s: openArray[string]): seq[string] =
-  for v in s:  result.add stripLinkOption(v)
+iterator passLinkOptions(opts: openArray[string]): string =
+  var passNext = false
+  template yields(x: untyped) = yield strip(x, true, true, {'\'', '\"'})
+  for s in opts:
+    if passNext:
+      passNext = false
+      yields s
+    elif s == "-e":
+      passNext = true
+      yield s
+    elif s == "--entry":
+      yield s
+    elif s.startsWith("-l"):
+      yield s
+    elif s == "--no-undefined":
+      yield s
+    elif s.startsWith("-rpath"):
+      yield s
+    elif s == "-r":
+      yield s
+    elif s == "-Xlinker":
+      passNext = true
+    elif s.startsWith("-Wl,"):
+      # TODO comma support
+      yields s[4..^1]
+    elif not s.startsWith("-"):
+      yields s
 
 proc findLibraries(s: string): seq[string] =
   for line in s.split('\n'):
     if line.startsWith("libraries: ="):
       return line["libraries: =".len..^1].split(':')
 
+proc findLastArg(args: openArray[string], opts: openArray[string]): string =
+  for i in 1..args.len:
+    if args[^i] in opts:
+      return args[^i]
+  return ""
+
+proc findFile(candidates: openArray[string], name: string): string =
+  for candidate in candidates:
+    if os.fileExists(candidate / name):
+      return candidate / name
+  ""
+
 proc linkLinuxAmd64(conf: ConfigRef) =
-  # The command line built here is based on clang 7 on Fedora 29 / x86_64 -
-  # it's likely to be wrong for anything else!
+  # This function emulates clang which emulates gcc which builds on 50 years
+  # of technical debt accumulation in the linker tooling space!
 
   # Ugly hack to reuse nim compiling of C files
   conf.globalOptions.incl optNoLinking
   callCCompiler(conf)
   conf.globalOptions.excl optNoLinking
 
+  let filePaths =
+    try:
+      let driver = CC[conf.cCompiler].compilerExe
+      findLibraries(execProcess(driver & " -print-search-dirs"))
+    except CatchableError:
+      @[]
+
+  let linkOpts =
+    parseCmdLine(conf.linkOptions) &
+    parseCmdLine(conf.linkOptionsCmd)
+
+  # Simplified version of (ie would need more work):
+  # https://github.com/llvm/llvm-project/blob/llvmorg-15.0.6/clang/lib/Driver/ToolChains/Gnu.cpp#L402
   var args: seq[string]
 
-  # TODO No idea what most of these options do or which are necessary..
   args.add "ld.lld"
-  args.add "--hash-style=gnu"
-  args.add "--no-add-needed"
-  args.add "--build-id"
-  args.add "--eh-frame-hdr"
-  args.add ["-m", "elf_x86_64"]
-  args.add ["-dynamic-linker", "/lib64/ld-linux-x86-64.so.2"]
 
-  let exeFile = conf.getOutFile(conf.outFile, platform.OS[conf.target.targetOS].exeExt)
+  let
+    isAndroid = conf.target.targetOS == osAndroid
+    pieArg = linkOpts.findLastArg(["-pie", "-no-pie", "-nopie"])
+    isPIE = not(
+      "-shared" in linkOpts or "-static" in linkOpts or "-r" in linkOpts or
+      "-static-pie" in linkOpts
+    ) and pieArg in ["-pie"] # `-pie` by default
+    isStaticPIE = "-static-pie" in linkOpts
+    isStatic = "-static" in linkOpts and not isStaticPIE
+    isCpp = optMixedMode in conf.globalOptions
+
+  if isPIE:
+    args.add "-pie"
+
+  if isStaticPIE:
+    args.add ["-static", "-pie", "--no-dynamic-linker", "-z", "text"]
+
+  if "-rdynamic" in linkOpts:
+    args.add ["-export-dynamic"]
+
+  if "-s" in linkOpts:
+    args.add ["-s"]
+
+  # Next follows a section of distro-specific flags:
+  # https://github.com/llvm/llvm-project/blob/llvmorg-15.0.6/clang/lib/Driver/ToolChains/Linux.cpp#L193
+
+  if isAndroid: # TODO or alpine linux
+    args.add ["-z", "now"]
+
+  if isAndroid: # TODO or suse/ubuntu/alpine linux
+    args.add ["-z", "relro"]
+
+  # Ancient distros would need --hash-style=both
+  args.add "--hash-style=gnu"
+
+  if isAndroid: # TODO or opensuse
+    args.add "--enable-new-dtags"
+
+  # TODO multiarch / multilib
+
+  args.add "--eh-frame-hdr"
+
+  args.add ["-m", "elf_x86_64"]
+
+  if "-shared" in linkOpts:
+    args.add "-shared"
+
+  if isStatic:
+    args.add "-static"
+  else:
+    if "-rdynamic" in linkOpts:
+      args.add "-export-dynamic"
+
+    if "-shared" notin linkOpts and not isStaticPIE and "-r" notin linkOpts:
+      args.add ["-dynamic-linker", "/lib64/ld-linux-x86-64.so.2"]
+
+  let exeFile = conf.prepareToWriteOutput()
 
   args.add ["-o", exefile.string]
 
-  args.add "/usr/lib64/crt1.o" # /usr/bin/../lib/gcc/x86_64-redhat-linux/8/../../../../lib64/crt1.o
-  args.add "/usr/lib64/crti.o" # /usr/bin/../lib/gcc/x86_64-redhat-linux/8/../../../../lib64/crti.o
+  if "-nostdlib" notin linkOpts and "-nostartfiles" notin linkOpts and "-r" notin linkOpts:
+    if not isAndroid:
+      let crt1 = if isPIE:
+        "Scrt1.o"
+      elif isStaticPIE:
+        "rcrt1.o"
+      else:
+        "crt1.o"
+      args.add findFile(filePaths, crt1)
 
-  # /usr/bin/../lib/gcc/x86_64-redhat-linux/8/crtbegin.o
+    # TODO adjust toolchain path
+    args.add "/usr/lib64/crti.o"
 
-  # -L/usr/bin/../lib/gcc/x86_64-redhat-linux/8
+    let crtbegin = if "-shared" in linkOpts:
+      if isAndroid: "crtbegin_so.o" else: "crtbeginS.o"
+    elif isStatic:
+      if isAndroid: "crtbegin_static.o" else: "crtbeginT.o"
+    elif isPIE or isStaticPIE:
+      if isAndroid: "crtbegin_dynamic.o" else: "crtbeginS.o"
+    else:
+      if isAndroid: "crtbegin_dynamic.o" else: "crtbegin.o"
 
-  # We're going to load all standard library locations that gcc uses, if possible
-  let libs =
-    try:
-      findLibraries(execProcess("gcc -print-search-dirs").string)
-    except:
-      @[]
+    args.add findFile(filePaths, crtbegin)
+  for opt in linkOpts:
+    if opt.startsWith("-L"):
+      args.add opt
+  for opt in linkOpts:
+    if opt.startsWith("-u"):
+      args.add opt
 
-  for lib in libs:
+  for lib in filePaths:
     args.add "-L" & lib
 
   # Then the project object files...
@@ -81,37 +184,64 @@ proc linkLinuxAmd64(conf: ConfigRef) =
   for x in conf.toCompile:
     args.add x.obj.string
 
-  args.add stripLinkOption(parseCmdLine(conf.linkOptions))
-  args.add stripLinkOption(parseCmdLine(conf.linkOptionsCmd))
+  for opt in passLinkOptions(linkOpts):
+    args.add opt
 
   for linkedLib in items(conf.cLinkedLibs):
-    args.add CC[conf.cCompiler].linkLibCmd % linkedLib.quoteShell
+    args.add parseCmdLine(CC[conf.cCompiler].linkLibCmd % linkedLib.quoteShell)
   for libDir in items(conf.cLibs):
-    args.add join([CC[conf.cCompiler].linkDirCmd, libDir.quoteShell])
+    args.add parseCmdLine(join([CC[conf.cCompiler].linkDirCmd, libDir.quoteShell]))
 
-  # And yet more standard linking options:
+  if "-nostdlib" notin linkOpts and "-r" notin linkOpts:
+    if isCpp:
+      if "-nostdlibxx" notin linkOpts and "-nodefaultlibs" notin linkOpts:
+        args.add "-lstdc++"
+        args.add "-lm"
 
-  args.add "-lstdc++"
-  args.add "-lm"
+    if "-nodefaultlibs" notin linkOpts:
+      if isStatic or isStaticPIE:
+        args.add "--start-group"
 
-  # args.add "-lgcc"
+      let wantPthread =
+        "-pthread" in linkOpts or
+        "-pthreads" in linkOpts or
+        optThreads in conf.globalOptions
 
-  # args.add "--as-needed"
-  # args.add "-lgcc_s"
-  # args.add "--no-as-needed"
-  args.add "-lc"
-  # args.add "-lgcc"
-  # args.add "--as-needed"
-  # args.add "-lgcc_s"
-  # args.add "--no-as-needed"
+      template addRuntimeLibs() =
+        if isStatic or isStaticPIE:
+          args.add ["-lgcc", "-lgcc_eh"]
+        elif "-shared" in linkOpts:
+          args.add "-lgcc_s"
+        else:
+          args.add ["-lgcc", "--as-needed", "-lgcc_s", "--no-as-needed"]
 
-  # /usr/bin/../lib/gcc/x86_64-redhat-linux/8/crtend.o
+      addRuntimeLibs()
+      if wantPthread:
+        args.add "-lpthread"
 
-  args.add "/usr/lib64/crtn.o" # /usr/bin/../lib/gcc/x86_64-redhat-linux/8/../../../../lib64/crtn.o
+      if "-nolibc" notin linkOpts:
+        args.add "-lc"
+
+      if isStatic or isStaticPIE:
+        args.add "--end-group"
+      else:
+        addRuntimeLibs()
+
+    let crtend = if "-shared" in linkOpts:
+      if isAndroid: "crtend_so.o" else: "crtendS.o"
+    elif isPIE or isStaticPIE:
+      if isAndroid: "crtend_android.o" else: "crtendS.o"
+    else:
+      if isAndroid: "crtend_android.o" else: "crtend.o"
+
+    args.add findFile(filePaths, crtend)
+
+    if not isAndroid:
+      args.add findFile(filePaths, "crtn.o")
 
   rawMessage(conf, hintLinking, $args)
 
-  if not nimLLDLinkWasm(args):
+  if not nimLLDLinkElf(args):
     rawMessage(conf, errGenerated, "linking failed")
     quit(1)
 
@@ -122,12 +252,14 @@ proc linkWasm32(conf: ConfigRef) =
 
   let exeFile = conf.getOutFile(conf.outFile, "wasm")
 
+  let linkOpts =
+    parseCmdLine(conf.linkOptions) &
+    parseCmdLine(conf.linkOptionsCmd)
+
   args.add ["-o", exefile.string]
 
-  # TODO this stripping of shell quoting and other stuff is pretty ugly - needs
-  #      a holistic review
-  args.add stripLinkOption(parseCmdLine(conf.linkOptions))
-  args.add stripLinkOption(parseCmdLine(conf.linkOptionsCmd))
+  for opt in passLinkOptions(linkOpts):
+    args.add opt
 
   for it in conf.externalToLink:
     args.add addFileExt(it, CC[conf.cCompiler].objExt)
@@ -145,8 +277,15 @@ proc linkWasm32(conf: ConfigRef) =
     quit(1)
 
 proc lllink*(conf: ConfigRef) =
-  if false and conf.target.targetOS == osLinux and conf.target.targetCPU == cpuAmd64:
-    # TODO this stuff is not ready for prime time..
+  let builtinLinker =
+    optGenStaticLib notin conf.globalOptions and
+    optGenGuiApp notin conf.globalOptions and
+    optGenDynLib notin conf.globalOptions and
+    conf.getConfigVar("nlvm.linker", "builtin") == "builtin" and
+    conf.cCompiler in {ccGcc, ccLLVM_Gcc, ccCLang}
+
+  if builtinLinker and conf.target.targetOS == osLinux and
+      conf.target.targetCPU == cpuAmd64:
     linkLinuxAmd64(conf)
   elif conf.target.targetCPU == cpuWasm32:
     linkWasm32(conf)

--- a/nlvm/lllink.nim
+++ b/nlvm/lllink.nim
@@ -154,8 +154,7 @@ proc linkLinuxAmd64(conf: ConfigRef) =
         "crt1.o"
       args.add findFile(filePaths, crt1)
 
-    # TODO adjust toolchain path
-    args.add "/usr/lib64/crti.o"
+    args.add findFile(filePaths, "crti.o")
 
     let crtbegin = if "-shared" in linkOpts:
       if isAndroid: "crtbegin_so.o" else: "crtbeginS.o"


### PR DESCRIPTION
* fix debug info for globals
* pass more options to linkers
* use `.init_array` instead of `.ctors` for GC registration of globals
* expose llvm codegen options in cli