### PR TITLE
fixes

### DIFF
--- a/llvm/llvm.nim
+++ b/llvm/llvm.nim
@@ -354,6 +354,13 @@ const
   False*: Bool = 0
   True*: Bool = 1
 
+  AllocFnKindAlloc* = 0x01'u64
+  AllocFnKindRealloc* = 0x02'u64
+  AllocFnKindFree* = 0x04'u64
+  AllocFnKindUninitialized* = 0x08'u64
+  AllocFnKindZeroed* = 0x10'u64
+  AllocFnKindAligned* = 0x20'u64
+
 template checkErr(body: untyped) =
   var err: cstring
   let e {.inject.} = cast[cstringArray](addr(err))
@@ -468,10 +475,14 @@ template getEnumAttrKind(x: untyped): untyped = getEnumAttributeKindForName(x, x
 let
   attrNoReturn* = getEnumAttrKind("noreturn")
   attrNoInline* = getEnumAttrKind("noinline")
+  attrNoUnwind* = getEnumAttrKind("nounwind")
   attrCold* = getEnumAttrKind("cold")
   attrAllockind* = getEnumAttrKind("allockind")
   attrAllocsize* = getEnumAttrKind("allocsize")
+  attrAllocptr* = getEnumAttrKind("allocptr")
   attrAlign* = getEnumAttrKind("align")
+  attrNonnull* = getEnumAttrKind("nonnull")
+  attrNoalias* = getEnumAttrKind("noalias")
 
 proc addFuncAttribute*(f: ValueRef, v: AttributeRef) =
   addAttributeAtIndex(f, cast[AttributeIndex](AttributeFunctionIndex), v)

--- a/nlvm-lib/nlvmbase-amd64-Linux.ll
+++ b/nlvm-lib/nlvmbase-amd64-Linux.ll
@@ -18,7 +18,7 @@ target triple = "x86_64-unknown-linux-gnu"
 @PTHREAD_BARRIER_SERIAL_THREAD = linkonce_odr constant i32 -1
 
 ; signal.h
-@SIG_IGN = global void (i32)* inttoptr (i64 1 to void (i32)*), align 8
+@SIG_IGN = linkonce_odr constant void (i32)* inttoptr (i64 1 to void (i32)*), align 8
 @SEGV_MAPERR = linkonce_odr constant i32 1
 
 ; stdio.h

--- a/skipped-tests.txt
+++ b/skipped-tests.txt
@@ -24,11 +24,9 @@ tests/casestmt/t7699.nim c
 tests/ccgbugs2/tinefficient_const_table.nim c
 tests/ccgbugs/t16027.nim c
 tests/ccgbugs/t19445.nim c --nimcache:tests/ccgbugs/nimcache19445 --cincludes:nimcache19445 --header:m19445
-tests/ccgbugs/targ_lefttoright.nim c
 tests/ccgbugs/tassign_nil_strings.nim c
 tests/ccgbugs/tcodegenbug_bool.nim c
 tests/ccgbugs/tcodegendecllambda.nim c
-tests/ccgbugs/tcompile_time_var_at_runtime.nim c
 tests/ccgbugs/tcvarargs.nim c
 tests/ccgbugs/tforward_decl_only.nim c
 tests/ccgbugs/tmangle_field.nim c
@@ -140,7 +138,6 @@ tests/overload/tstatic_with_converter.nim c
 tests/parallel/tdeepcopy2.nim c
 tests/parallel/tdeepcopy.nim c
 tests/parallel/tmissing_deepcopy.nim c
-tests/pragmas/t12640.nim c
 tests/pragmas/tbitsize.nim c
 tests/pragmas/tnoreturn.nim c
 tests/realtimeGC/tmain.nim c


### PR DESCRIPTION
* avoid visible SIG_IGN symbol
* alignment and noaliasing for memory allocators -> better codegen
* fix LTR eval order
* avoid unnecessary copies on object init / block expr / etc
* fix compile-time var reinitialization
* better global initialization when value is constexpr