### PR TITLE
Add Windows/mingw32 support, native and cross

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,14 +1,17 @@
 name: Continuous
 on: [push, pull_request]
 jobs:
-  build:
+  Linux:
+    defaults:
+      run:
+        shell: bash
     runs-on: ubuntu-22.04
     steps:
       - name: Install deps
         run: |
           sudo add-apt-repository universe
           sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev libsdl1.2-dev libgc-dev libncurses5-dev jq cmake ninja-build clang libfuse2 valgrind libncurses5
+          sudo apt-get install -y libcurl4-openssl-dev libsdl1.2-dev libgc-dev libncurses5-dev jq cmake ninja-build clang libfuse2 valgrind libncurses5 libzstd-dev
       - name: Check out repository code
         uses: actions/checkout@v6
         with:
@@ -42,16 +45,112 @@ jobs:
       - name: Run self-compare
         run: make STATIC_LLVM=1 compare
 
+      - name: Cross-compile
+        run: |
+          ./dl-llvm-mingw.sh
+          ./env.sh nlvm/nlvmr c --os:windows Nim/compiler/nim
+          [ -f Nim/compiler/nim.exe ] || { echo "nim.exe missing" ; exit 1 ; }
+
       - name: Create distribution
-        run: bash make-dist.sh
+        run: bash make-dist-linux.sh
 
       - name: Update release
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Local copy of the following script:
           # wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+          bash upload.sh dist/*
+
+  Windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: clang64
+          install: >-
+            git
+            make
+            diffutils
+            tar
+            zip
+          pacboy: >-
+            toolchain:p
+            cmake:p
+            ninja:p
+            gcc:p
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Set up environment
+        shell: bash
+        run: |
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+          echo "LD=clang++" >> $GITHUB_ENV
+          echo "LLVM_VERSION=$(cat llvm/llvm.version)" >> $GITHUB_ENV
+          echo "PATH=$PATH:$PWD/llvm-ming-20251216-ucrt-x86_64/bin >> $GITHUB_ENV"
+
+      - name: Cache Nim DLLs (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/cache@v4
+        id: cache-nim-dlls
+        with:
+          path: nim-dlls.zip
+          key: nim-dlls-${{ runner.os }}
+
+      - name: Download Nim DLLs (Windows)
+        if: runner.os == 'Windows' && steps.cache-nim-dlls.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri https://nim-lang.org/download/dlls.zip -OutFile nim-dlls.zip
+
+      - name: Setup Nim DLLs (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Expand-Archive -Path nim-dlls.zip -DestinationPath nim-dlls -Force
+          echo "$Env:GITHUB_WORKSPACE\nim-dlls" >> $Env:GITHUB_PATH
+          echo "SSL_CERT_FILE=$Env:GITHUB_WORKSPACE\nim-dlls\cacert.pem" >> $Env:GITHUB_ENV
+
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v5
+        with:
+          path: |
+            llvm/sta
+          key: llvm-${{ runner.os }}-${{ env.LLVM_VERSION }}
+
+      - name: Set up llvm
+        run: make STATIC_LLVM=1 prepare-llvm
+
+      - name: Compile nim
+        run: make STATIC_LLVM=1 prepare-nim
+
+      - name: Run tests
+        run: |
+          cat ci-skipped-tests.txt >>skipped-tests.txt
+          make STATIC_LLVM=1 test || true # TODO enable hard fail on tests
+
+      - name: Run self-compare
+        # On windows, nlvm.self cannot raise exceptions, likely due to a conflict
+        # with libunwind in libc++ - this needs further investigation
+        run: make STATIC_LLVM=1 compare || true
+
+      - name: Create distribution
+        run: bash make-dist-windows.sh
+
+      - name: Update release
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: msys2 {0}
+        run: |
           bash upload.sh dist/*
 
   nph:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,3 @@
-NIMC=Nim/bin/nim
-
-NLVMC=nlvm/nlvm
-NLVMR=nlvm/nlvmr
-
 #NIMFLAGS=--opt:speed --gc:markandsweep
 #NIMFLAGS=-d:release
 NIMFLAGS=--debuginfo --linedir:on --cc=clang
@@ -13,19 +8,36 @@ LLVM_MAJ:=$(shell cat llvm/llvm.version | cut -f1 -d.)
 LLVM_MIN:=$(shell cat llvm/llvm.version | cut -f2 -d.)
 LLVM_PAT:=$(shell cat llvm/llvm.version | cut -f3 -d.)
 
+# Extension for executables on Windows
+ifeq ($(OS),Windows_NT)
+EXE := .exe
+LLVM_DLL := llvm/sha/bin/libLLVM-$(LLVM_MAJ).dll
+STATIC_OPT := -DLLVM_BUILD_STATIC=1
+else
+EXE :=
+LLVM_DLL := llvm/sha/lib/libLLVM.so.$(LLVM_MAJ).$(LLVM_MIN)
+
+# Fully static compilation of `nlvm` itself not supported (yet? patches welcome)
+STATIC_OPT :=
+endif
+
+NIMC=Nim/bin/nim$(EXE)
+NLVMC=nlvm/nlvm$(EXE)
+NLVMR=nlvm/nlvmr$(EXE)
+
 ifdef STATIC_LLVM
-	NLVMCFLAGS=-d:staticLLVM --dynliboverrideall
-	LLVM_DEP=llvm/sta/bin/llvm-config
+	NLVMCFLAGS=-d:staticLLVM
+	LLVM_DEP=llvm/sta/bin/llvm-config$(EXE)
 	export PATH := $(PWD)/llvm/sta/bin:$(PATH)
 else
-	LLVM_DEP=llvm/sha/lib/libLLVM.so.$(LLVM_MAJ).$(LLVM_MIN)
+	LLVM_DEP:=$(LLVM_DLL)
 	NLVMCFLAGS?=
 endif
 
 .PHONY: all
 all: $(NLVMC)
 
-Nim/koch:
+Nim/koch$(EXE):
 	cd Nim ;\
 	[ -d csources_v2 ] || git clone -q --depth 1 -b master https://github.com/nim-lang/csources_v2.git ;\
 	cd csources_v2 ;\
@@ -33,32 +45,32 @@ Nim/koch:
 	$(MAKE) -f makefile
 	cd Nim ; bin/nim c koch
 
-$(NIMC): Nim/koch Nim/compiler/*.nim
+$(NIMC): Nim/koch$(EXE) Nim/compiler/*.nim
 	cd Nim && ./koch boot -d:release
 
 $(NLVMC): $(LLVM_DEP) $(NIMC) Nim/compiler/*.nim  nlvm/*.nim llvm/*.nim nlvm-lib/*.nim
 	cd nlvm && time ../$(NIMC) $(NIMFLAGS) $(NLVMCFLAGS) c nlvm
 
 $(NLVMR): $(LLVM_DEP) $(NIMC) Nim/compiler/*.nim  nlvm/*.nim llvm/*.nim nlvm-lib/*.nim
-	cd nlvm && time ../$(NIMC) $(NIMFLAGS) -d:release $(NLVMCFLAGS) -o:nlvmr c nlvm
+	cd nlvm && time ../$(NIMC) $(NIMFLAGS) -d:release $(NLVMCFLAGS) -o:nlvmr$(EXE) c nlvm
 
 nlvm/nlvm.ll: $(NLVMC) nlvm/*.nim llvm/*.nim nlvm-lib/*.nim
 	cd nlvm && time ./nlvm $(NLVMFLAGS) -o:nlvm.ll $(NLVMCFLAGS) -c c nlvm
 
-nlvm/nlvm.self: $(NLVMC)
-	cd nlvm && time ./nlvm -o:nlvm.self $(NLVMFLAGS) $(NLVMCFLAGS) c nlvm
+nlvm/nlvm.self$(EXE): $(NLVMC)
+	cd nlvm && time ./nlvm -o:nlvm.self$(EXE) $(NLVMFLAGS) $(NLVMCFLAGS) c nlvm
 
-nlvm/nlvmr.self: $(NLVMR)
-	cd nlvm && time ./nlvmr -o:nlvmr.self -d:release $(NLVMFLAGS) $(NLVMCFLAGS) c nlvm
+nlvm/nlvmr.self$(EXE): $(NLVMR)
+	cd nlvm && time ./nlvmr -o:nlvmr.self$(EXE) -d:release $(NLVMFLAGS) $(NLVMCFLAGS) c nlvm
 
-nlvm/nlvm.self.ll: nlvm/nlvm.self
+nlvm/nlvm.self.ll: nlvm/nlvm.self$(EXE)
 	cd nlvm && time ./nlvm.self -c $(NLVMFLAGS) $(NLVMCFLAGS) -o:nlvm.self.ll c nlvm
 
 .PHONY: compare
 compare: nlvm/nlvm.self.ll nlvm/nlvm.ll
 	diff -u nlvm/nlvm.self.ll nlvm/nlvm.ll
 
-Nim/testament/testament: $(NIMC) Nim/testament/*.nim
+Nim/testament/testament$(EXE): $(NIMC) Nim/testament/*.nim
 	$(NIMC) -d:release c Nim/testament/testament
 
 .PHONY: run-testament run-testament-noskip
@@ -95,11 +107,11 @@ self: nlvm/nlvm.self
 
 .PHONY: clean
 clean:
-	rm -rf $(NLVMC) $(NLVMR) nlvm/nlvm.ll nlvm/nlvm.self.ll nlvm/nlvm.self Nim/testresults/
+	rm -rf $(NLVMC) $(NLVMR) nlvm/nlvm.ll nlvm/nlvm.self.ll nlvm/nlvm.self$(EXE) Nim/testresults/
 
 # developer build - build all of llvm including tooling like IR inspectors etc
 # for the right version of LLVM
-llvm/sha/lib/libLLVM.so.$(LLVM_MAJ).$(LLVM_MIN):
+$(LLVM_DLL):
 	sh ./make-llvm.sh sha "" \
 		-DLLVM_BUILD_LLVM_DYLIB=1 \
 		-DLLVM_LINK_LLVM_DYLIB=1 \
@@ -107,10 +119,11 @@ llvm/sha/lib/libLLVM.so.$(LLVM_MAJ).$(LLVM_MIN):
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 # We only need a subset of the build in CI / statically linked release builds
-llvm/sta/bin/llvm-config:
+llvm/sta/bin/llvm-config$(EXE):
 	sh ./make-llvm.sh sta "lld-libraries lib/all llvm-config" \
 		-DLLVM_BUILD_LLVM_DYLIB=0 \
 		-DLLVM_LINK_LLVM_DYLIB=0 \
+		$(STATIC_OPT) \
 		-DLLVM_ENABLE_ASSERTIONS=0 \
 		-DCMAKE_BUILD_TYPE=Release
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- omit in toc -->
 # Introduction
 
 [nlvm](https://github.com/arnetheduck/nlvm) (the nim-level virtual machine?)
@@ -14,6 +15,27 @@ Fork and enjoy!
 
 Jacek Sieka (arnetheduck on gmail point com)
 
+<!-- omit in toc -->
+## Table of contents
+
+- [Features](#features)
+- [Installation](#installation)
+  - [Binaries](#binaries)
+  - [Compiling `nlvm`](#compiling-nlvm)
+- [Compiling your code](#compiling-your-code)
+  - [Pipeline](#pipeline)
+  - [Porting guide](#porting-guide)
+    - [dynlib](#dynlib)
+    - [{.header.}](#header)
+    - [{.emit.}](#emit)
+    - [{.asm.}](#asm)
+- [wasm32](#wasm32)
+- [Cross compiler](#cross-compiler)
+  - [Prerequisites](#prerequisites)
+  - [Compiling](#compiling)
+- [REPL / running your code](#repl--running-your-code)
+- [Random notes](#random-notes)
+
 # Features
 
 `nlvm` works as a drop-in replacement for `nim` with the following notable differences:
@@ -27,15 +49,19 @@ Jacek Sieka (arnetheduck on gmail point com)
   * compiler-intrinsic guided optimisation for overflow checking, memory operations, exception handling
   * heap allocation elision
   * native constant initialization
-* Native `wasm32` support with no extra tooling
+* Native cross compiler, including `wasm32` support with no extra tooling
 * Native integrated fast linker (`lld`)
 * Just-in-time execution and REPL (`nlvm r`) using the LLVM [ORCv2 JIT](https://llvm.org/docs/ORCv2.html)
+* Built-in [cross-compiler](#cross-compiler)
 
 Most things from `nim` work just fine (see the [porting guide](#porting-guide) below!):
 
 * the same standard library is used
 * similar command line options are supported (just change `nim` to `nlvm`!)
-* `C` header files are not used - the declaration in the `.nim` file needs to be accurate
+* `C` header files are not used - the declaration in the `.nim` file needs to be
+  accurate
+* If your program has `{.compile.}` dependencies, these work as usual but
+  require a corresponding compiler to be installed (ie clang, gcc)
 
 Test coverage is not too bad either:
 
@@ -44,15 +70,16 @@ Test coverage is not too bad either:
   the standard library and compiler relying on C implementation details - see
   [skipped-tests.txt](skipped-tests.txt) for an updated list of issues
 * compiling most applications
-* platforms: linux/x86_64, wasm32 (pre-alpha!)
+* platforms with tests:
+  * Linux/x86_64
+  * Windows/x86_64
 * majority of the nim standard library (the rest can be fixed easily -
   requires upstream changes however)
 
 How you could contribute:
 
 * work on making [skipped-tests.txt](skipped-tests.txt) smaller
-* improve platform support (`osx` and `windows` should be easy, `arm` would be
-  nice)
+* improve platform support (`osx` should be easy, `arm` would be nice)
 * help `nlvm` generate better IR - optimizations, builtins, exception handling..
 * help upstream make std library smaller and more `nlvm`-compatible
 * send me success stories :)
@@ -61,30 +88,44 @@ How you could contribute:
 `nlvm` does _not_:
 
 * understand `C` - as a consequence, `header`, `emit` and similar pragmas
-  will not work - neither will the fancy `importcpp`/`C++` features - see the [porting guide](#porting-guide) below!
+  are ignored - neither will the fancy `importcpp`/`C++` features - see the
+  [porting guide](#porting-guide) below!
 * support all nim compiler flags and features - do file bugs for anything
   useful that's missing
 
-# Compile instructions
+# Installation
+
+## Binaries
+
+Binaries are available from the [github releases](https://github.com/arnetheduck/nlvm/releases) page.
+
+## Source code
 
 To do what I do, you will need:
-* Linux
-* A C/C++ compiler (ironically, I happen to use `gcc` most of the time)
+
+* A C/C++ compiler
+  * `gcc` on Linux
+  * `clang` on Windows
+* A cup of tea and a good book
+  * Compiling `llvm` takes about an hour the first time (then it's cached)
 
 Start with a clone:
 
     cd $SRC
-    git clone https://github.com/arnetheduck/nlvm.git
-    cd nlvm && git submodule update --init
+    git clone https://github.com/arnetheduck/nlvm.git --recurse-submodules
+    cd nlvm
 
 We will need a few development libraries installed, mainly due to how `nlvm`
 processes library dependencies (see dynlib section below):
 
     # Fedora
-    sudo dnf install pcre-devel openssl-devel sqlite-devel ninja-build cmake
+    sudo dnf install pcre-devel openssl-devel sqlite-devel ninja-build cmake clang libzstd-devel
 
     # Debian, ubuntu etc
-    sudo apt-get install libpcre3-dev libssl-dev libsqlite3-dev ninja-build cmake
+    sudo apt-get install libpcre3-dev libssl-dev libsqlite3-dev ninja-build cmake clang libzstd-dev
+
+    # MSYS2 CLANG64 (note that we need the gcc shim for clang)
+    pacboy -S toolchain cmake ninja gcc
 
 Compile `nlvm` (if needed, this will also build `nim` and `llvm`):
 
@@ -125,9 +166,8 @@ To run built `nlvm` docker image use:
 
 On the command line, `nlvm` is mostly compatible with `nim`.
 
-When compiling, `nlvm` will generate a single `.o` file with all code from your
-project and link it using `$CC` - this helps it pick the right flags for
-linking with the C library.
+For compiling pure Nimm code, you do not need a C compiler - `nlvm` will compile
+and link the code using the built-in `lld` linker:
 
     cd $SRC/nlvm/Nim/examples
     ../../nlvm/nlvm c fizzbuzz
@@ -148,7 +188,7 @@ You can then run the LLVM optimizer on it:
     less fizzbuzz.s
 
 Apart from the code of your `.nim` files, the compiler will also mix in the
-compatibility found library in `nlvm-lib/`.
+compiler runtime library in `nlvm-lib/`.
 
 ## Pipeline
 
@@ -203,7 +243,6 @@ the signature of the declaration, meaning the declaration must _exactly_ match
 the `c` header file or subtly ABI issues and crashes ensue!
 
 ```nim
-
 # When `nim` encounters this, it will emit `jmp_buf` in the `c` code without
 # knowing the true size of the type, letting the `c` compiler determine it
 # instead.
@@ -237,6 +276,7 @@ when defined(linux) and defined(amd64):
 ```
 
 ### {.emit.}
+
 To deal with `emit`, the recommendation is to put the emitted code in a C file
 and `{.compile.}` it.
 
@@ -257,7 +297,56 @@ Similar to `{.emit.}`, `{.asm.}` functions must be moved to a separate file and
 included in the compilation with `{.compile.}` - this works both with `.S` and
 `.c` files.
 
-### wasm32 support
+# Cross compiler
+
+`nlvm` can be used to cross-compile code for a different platform, for example to
+create `Windows` executables on a `Linux` machine.
+
+## Prerequisites
+
+For cross-compilation, a `clang`-based environment for that platform must first
+be [set up](https://clang.llvm.org/docs/CrossCompilation.html) - the environment
+consists of:
+
+* a `sysroot` - the basic libraries needed to create executables for the platform
+  * for `Windows`, this is [llvm-mingw](https://github.com/mstorsjo/llvm-mingw/releases)
+  * It can be [obtained](https://mcilloni.ovh/2021/02/09/cxx-cross-clang/)
+    from the environment you're targeting.
+* The compiler runtime for that target (`compiler-rt` or `libgcc`)
+  * provided by `llvm-mingw`
+* `clang` - for finding libraries in the sysroot and dealing with `{.compile.}`
+  * a cross-compilation version of `gcc` may also work, though this hasn't been
+    tested
+
+## Compiling
+
+Once the `sysroot` is set up, compiling is as easy as selecting an alternative
+OS / CPU using the standard Nim flags, `--os:` and `--cpu:`.
+
+### Windows
+
+A helper script exists to set up `llvm-mingw`:
+
+```sh
+./dl-llvm-mingw.sh
+
+# Set up $PATH to include the `clang` compiler that comes with llvm-mingw
+. env.sh
+```
+
+```sh
+# Assuming we're on Linux, compile for Windows and link dependencies statically
+# to create a (mostly) stand-alone binary:
+nlvm c --os:windows --passl:-static test.nim
+
+# You can also use a target triple
+nlvm c --nlvm.triple=x86_64-w64-mingw32 --passl:-static Nim/examples/fizzbuzz.nim
+
+# Run the compiled program via wine
+wine test.exe
+```
+
+### wasm32
 
 Use `--cpu:wasm32 --os:standalone --gc:none` to compile Nim to (barebones) WASM.
 
@@ -265,8 +354,8 @@ You will need to provide a runtime (ie WASI) and use manual memory allocation as
 the garbage collector hasn't yet been ported to WASM and the Nim standard
 library lacks WASM / WASI support.
 
-To compile wasm files, you will thus need a `panicoverride.nim` - a minimal
-example looks like this and discards any errors:
+Apart from WASI, an implementation of `panicoverride.nim` also needs to be
+provided - here's one that discards all panics:
 
 ```nim
 # panicoverride.nim
@@ -284,7 +373,7 @@ proc adder*(v: int): int {.exportc.} =
 ```
 
 ```sh
-nlvm c --cpu:wasm32 --os:standalone --gc:none --passl:--no-entry myfile.nim
+nlvm c --cpu:wasm32 --os:standalone --gc:none --passl:-Wl,--no-entry myfile.nim
 wasm2wat -l myfile.wasm
 ```
 
@@ -294,7 +383,7 @@ in particular, the bulk memory extension is needed to process data.
 Extensions are enabled by passing `--passc:-mattr=+feature,+feature2`, for example:
 
 ```sh
-nlvm c --cpu:wasm32 --os:standalone --gc:none --passl:--no-entry --passc:-mattr=+bulk-memory
+nlvm c --cpu:wasm32 --os:standalone --gc:none --passl:-Wl,--no-entry --passc:-mattr=+bulk-memory
 ```
 
 Passing `--passc:-mattr=help` will print available features (only works while compiling, for now!)

--- a/dl-llvm-mingw.sh
+++ b/dl-llvm-mingw.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p ext
+cd ext
+
+# llvm-mingw version should preferably match llvm.version
+TAG="20251216"
+ROOT=llvm-mingw-$TAG-ucrt-ubuntu-22.04-x86_64
+
+[ -f llvm-mingw/bin/clang ] || {
+  [ -f $ROOT.tar.xz ] || {
+    wget https://github.com/mstorsjo/llvm-mingw/releases/download/$TAG/$ROOT.tar.xz
+  }
+
+  tar xvf $ROOT.tar.xz
+  mv $ROOT llvm-mingw
+}

--- a/env.sh
+++ b/env.sh
@@ -3,15 +3,14 @@
 REL_PATH="$(dirname ${BASH_SOURCE[0]:-${(%):-%x}})"
 ABS_PATH="$(cd ${REL_PATH}; pwd)"
 
-export PATH="$ABS_PATH/Nim/bin:$ABS_PATH/llvm/sha/bin:$PATH"
+export PATH="$ABS_PATH/Nim/bin:$ABS_PATH/llvm/sha/bin:$ABS_PATH/ext/llvm-mingw/bin:$PATH"
 
 if [[ $# == 1 && $1 == "bash" ]]; then
         # the only way to change PS1 in a child shell, apparently
 # (we're not getting the original PS1 value in here, so set a complete and nice prompt)
-        export PS1="[Nimbus env] \[\033[0;31m\]\l \[\033[1;33m\]\d \[\033[1;36m\]\t \[\033[0;32m\]|\w|\[\033[0m\]\n\u\$ "
+        export PS1="[nlvm env] \[\033[0;31m\]\l \[\033[1;33m\]\d \[\033[1;36m\]\t \[\033[0;32m\]|\w|\[\033[0m\]\n\u\$ "
         exec "$1" --login --noprofile
 else
         # can't use "exec" here if we're getting function names as params
         "$@"
 fi
-

--- a/llvm/README.md
+++ b/llvm/README.md
@@ -1,11 +1,11 @@
 LLVM wrappers for the llvm-c interfaces to llvm.
 
-Generated using c2nim
+Generated using [c2nim](https://github.com/nim-lang/c2nim)
 
 Structure:
 
-llvm/ - c2nim-generated interface files
-llvm-project/ - LLVM source code (or at least the relevant parts)
-llvm.nim - helpers to make the generated files easier to use
-rebuild.sh - helper to regenerate wrappers
-update-llvm-project.sh - update llvm-projects mirror
+* llvm/ - c2nim-generated interface files
+* llvm-project/ - LLVM source code (or at least the relevant parts)
+* llvm.nim - helpers to make the generated files easier to use
+* rebuild.sh - helper to regenerate wrappers
+* update-llvm-project.sh - update llvm-projects mirror

--- a/llvm/llvm.nim
+++ b/llvm/llvm.nim
@@ -2,11 +2,12 @@
 # Copyright (c) Jacek Sieka 2016
 # See the LICENSE file for license info (doh!)
 
-import std/[os, strformat, strutils]
+import std/[os, pathnorm, strutils]
 
 const
-  currentSourceDir = currentSourcePath.parentDir
-  LLVMVersion* = staticRead(currentSourceDir / "llvm.version")
+  currentSourceDir = currentSourcePath.parentDir.normalizePath(dirSep = '/')
+  LLVMVersion* =
+    staticRead(normalizePath(currentSourceDir / "llvm.version", dirSep = '/'))
   LLVMMaj* = parseInt(LLVMVersion.split('.')[0])
   LLVMMin* = parseInt(LLVMVersion.split('.')[1])
   LLVMPat* = parseInt(LLVMVersion.split('.')[2])
@@ -14,6 +15,7 @@ const
   LLVMRoot = currentSourceDir / "llvm-project" / "llvm"
   LLDRoot = currentSourceDir / "llvm-project" / "lld"
 
+{.passL: "-llldCOFF".}
 {.passL: "-llldELF".}
 {.passL: "-llldWasm".}
 {.passL: "-llldMinGW".}
@@ -28,8 +30,12 @@ when defined(staticLLVM):
 else:
   const LLVMOut = currentSourceDir / "sha"
 
-  {.passL: fmt"-lLLVM".}
-  {.passL: "-Wl,'-rpath=$ORIGIN/" & LLVMOut & "/lib/'".}
+  when defined(windows):
+    import strformat
+    {.passL: &"-lLLVM-{LLVMMaj}".}
+  else:
+    {.passL: "-lLLVM".}
+    {.passL: "-Wl,'-rpath=$ORIGIN/../llvm/sha/lib/'".}
 
   {.passC: "-I" & LLVMOut / "include".}
   {.passC: "-I" & LLVMRoot / "include".}
@@ -38,7 +44,6 @@ else:
 
 {.passL: "-flto=thin".}
 {.passL: "-Wl,--as-needed".}
-{.passL: "-Wl,--export-dynamic".}
 {.passL: gorge(LLVMOut / "bin/llvm-config --ldflags").}
 {.passL: gorge(LLVMOut / "bin/llvm-config --system-libs").}
 
@@ -409,6 +414,17 @@ proc nimLLDLinkElf*(
   argv: cstringArray, argc: csize_t
 ): bool {.importc: "LLVMNimLLDLinkElf".}
 
+proc nimLLDLinkCoff*(
+  argv: cstringArray, argc: csize_t
+): bool {.importc: "LLVMNimLLDLinkCoff".}
+
+proc nimLLDLinkCoff*(args: openArray[string]): bool =
+  let argv = allocCStringArray(args)
+  defer:
+    deallocCStringArray(argv)
+
+  nimLLDLinkCoff(argv, args.len.csize_t)
+
 proc nimLLDLinkElf*(args: openArray[string]): bool =
   let argv = allocCStringArray(args)
   defer:
@@ -426,6 +442,17 @@ proc nimLLDLinkWasm*(args: openArray[string]): bool =
     deallocCStringArray(argv)
 
   nimLLDLinkWasm(argv, args.len.csize_t)
+
+proc nimLLDLinkMingw*(
+  argv: cstringArray, argc: csize_t
+): bool {.importc: "LLVMNimLLDLinkMingw".}
+
+proc nimLLDLinkMingw*(args: openArray[string]): bool =
+  let argv = allocCStringArray(args)
+  defer:
+    deallocCStringArray(argv)
+
+  nimLLDLinkMingw(argv, args.len.csize_t)
 
 proc nimCreateTargetMachine*(
   t: TargetRef,
@@ -648,5 +675,10 @@ proc appendBasicBlockInContext*(
 
 proc normalizeTargetTriple*(s: string): string =
   let tmp = normalizeTargetTriple(cstring(s))
+  result = $tmp
+  disposeMessage(tmp)
+
+proc triple*(tm: TargetMachineRef): string =
+  let tmp = getTargetMachineTriple(tm)
   result = $tmp
   disposeMessage(tmp)

--- a/llvm/wrapper.cc
+++ b/llvm/wrapper.cc
@@ -64,6 +64,18 @@ extern "C" bool LLVMNimLLDLinkWasm(const char **args, size_t arg_count) {
   return lld::wasm::link(array_ref_args, llvm::outs(), llvm::errs(), false, false);
 }
 
+LLD_HAS_DRIVER(coff)
+extern "C" bool LLVMNimLLDLinkCoff(const char **args, size_t arg_count) {
+  ArrayRef<const char *> array_ref_args(args, arg_count);
+  return lld::coff::link(array_ref_args, llvm::outs(), llvm::errs(), false, false);
+}
+
+LLD_HAS_DRIVER(mingw)
+extern "C" bool LLVMNimLLDLinkMingw(const char **args, size_t arg_count) {
+  ArrayRef<const char *> array_ref_args(args, arg_count);
+  return lld::mingw::link(array_ref_args, llvm::outs(), llvm::errs(), false, false);
+}
+
 static codegen::RegisterCodeGenFlags CGF;
 
 static Target *unwrap(LLVMTargetRef P) {

--- a/make-dist-linux.sh
+++ b/make-dist-linux.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-ROOT=nlvm-$(git rev-parse --short HEAD)
+ROOT=nlvm-linux-$(git rev-parse --short HEAD)
 
 rm -rf $ROOT
 
@@ -16,6 +16,7 @@ make STATIC_LLVM=1 nlvm/nlvmr
 # TODO these would go in /usr/{bin, share/Nim} normally
 mkdir -p $ROOT
 cp nlvm/nlvmr $ROOT/nlvm
+strip $ROOT/nlvm
 cp -r nlvm-lib $ROOT
 mkdir -p $ROOT/Nim
 cd Nim

--- a/make-dist-windows.sh
+++ b/make-dist-windows.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Experimental release script
+
+set -e
+
+ROOT=nlvm-windows-$(git rev-parse --short HEAD)
+
+rm -rf $ROOT
+
+# Make sure the nlvm binary is fresh
+rm -f nlvm/nlvmr.exe
+make STATIC_LLVM=1 nlvm/nlvmr.exe
+
+# Copy nlvm and library files
+# TODO these would go in /usr/{bin, share/Nim} normally
+mkdir -p $ROOT
+cp nlvm/nlvmr.exe $ROOT/nlvm.exe
+strip $ROOT/nlvm.exe
+cp -r nlvm-lib $ROOT
+mkdir -p $ROOT/Nim
+cd Nim
+# avoid build junk
+git archive --format=tar HEAD lib config | (cd ../$ROOT/Nim && tar xf -)
+cd ..
+
+rm -rf dist
+mkdir -p dist
+zip -r dist/$ROOT.zip $ROOT/
+
+rm -rf $ROOT

--- a/nlvm-lib/nlvm_unwind.nim
+++ b/nlvm-lib/nlvm_unwind.nim
@@ -53,7 +53,10 @@ type
   UnwindException* = object
     exceptionClass*: uint64
     exceptionCleanup*: UnwindExceptionCleanupFn
-    private1, private2: uint
+    when defined(windows):
+      private: array[6, uint]
+    else:
+      private1, private2: uint
 
     when sizeof(pointer) == 4:
       reserved: array[3, uint32]

--- a/nlvm-lib/nlvmbase-wasm32-Standalone.ll
+++ b/nlvm-lib/nlvmbase-wasm32-Standalone.ll
@@ -1,4 +1,4 @@
 ; base presently used for wasm32!
 
-target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-unknown"

--- a/nlvm/llgen.nim
+++ b/nlvm/llgen.nim
@@ -200,16 +200,12 @@ proc llPassAsPtr(g: LLGen, s: PSym, retType: PType): bool
 proc llType(g: LLGen, typ: PType, deep = true): llvm.TypeRef
 proc llStructType(g: LLGen, typ: PType, deep: bool): llvm.TypeRef
 proc llTupleType(g: LLGen, typ: PType, deep: bool): llvm.TypeRef
-proc llProcType(g: LLGen, typ: PType, closure = false): llvm.TypeRef
-proc llStringType(g: LLGen): llvm.TypeRef
 proc llGenericSeqType(g: LLGen): llvm.TypeRef
 proc llOpenArrayType(g: LLGen): llvm.TypeRef
 proc llClosureType(g: LLGen): llvm.TypeRef
-proc llMagicType(g: LLGen, name: string): llvm.TypeRef
 proc llSeqType(g: LLGen, typ: PType): llvm.TypeRef
 proc fieldIndex(g: LLGen, typ: PType, sym: PSym): seq[FieldPath]
 proc callMemset(g: LLGen, tgt, v, len: llvm.ValueRef)
-proc callErrno(g: LLGen, prefix: string): llvm.ValueRef
 proc callCompilerProc(
   g: LLGen,
   name: string,
@@ -3497,7 +3493,7 @@ proc paramStorageLoc(param: PSym): TStorageLoc =
   if param.typ.skipTypes({tyVar, tyTypeDesc, tyLent}).kind notin
       {tyArray, tyOpenArray, tyUncheckedArray, tyVarargs}: OnStack else: OnUnknown
 
-proc llProcType(g: LLGen, typ: PType, closure: bool): llvm.TypeRef =
+proc llProcType(g: LLGen, typ: PType, closure = false): llvm.TypeRef =
   var
     retType =
       if typ[0] == nil:
@@ -3691,99 +3687,6 @@ proc preCast(
 
   ax
 
-proc externGlobal(g: LLGen, s: PSym): LLValue =
-  # Extra symbols that the compiler fetches from header files - we'll need
-  # a better solution than hard-coding them, at some point
-  # These are typically "nodecl", "importc" and/or "header" tagged in
-  # the std library
-  let
-    name = g.llName(s)
-    t = g.llType(s.typ)
-
-  case name
-  of "errno":
-    LLValue(v: g.callErrno(""))
-  of "h_errno":
-    LLValue(v: g.callErrno("h_"))
-  else:
-    if s.id in g.symbols and not g.interactive():
-      g.symbols[s.id]
-    elif (let v = g.m.getNamedGlobal(name); v != nil):
-      let tmp = LLValue(v: v, storage: s.loc.storage)
-      g.symbols[s.id] = tmp
-      tmp
-    else:
-      let tmp = LLValue(v: g.m.addGlobal(t, name))
-      g.symbols[s.id] = tmp
-      tmp
-
-proc genLocal(g: LLGen, n: PNode): LLValue =
-  let s = n.sym
-  if s.loc.k == locNone:
-    fillLoc(s.loc, locLocalVar, n, s.name.s.mangle.rope, OnStack)
-    if s.kind == skLet:
-      incl(s.loc.flags, lfNoDeepCopy)
-
-  let
-    t = g.llType(s.typ)
-    v = g.localAlloca(t, g.llName(s))
-  g.debugVariable(s, v)
-
-  if s.kind in {skLet, skVar, skField, skForVar} and s.alignment > 0:
-    v.setAlignment(cuint s.alignment)
-
-  let lv = LLValue(v: v, lode: n, storage: s.loc.storage)
-  g.symbols[s.id] = lv
-  lv
-
-proc genGlobal(g: LLGen, n: PNode, isConst: bool): LLValue =
-  let s = n.sym
-
-  if s.id in g.symbols:
-    let
-      name = g.llName(s)
-      t = g.llType(s.typ.skipTypes(abstractInst))
-
-    return g.refGlobal(g.symbols[s.id], name, t)
-
-  if s.loc.k == locNone:
-    fillLoc(s.loc, locGlobalVar, n, g.mangleName(s), if isConst: OnStatic else: OnHeap)
-
-  let name = g.llName(s)
-
-  # Couldn't find by id - should we get by name also? this seems to happen for
-  # stderr for example which turns up with two different id:s.. what a shame!
-  if (let v = g.m.getNamedGlobal(name); v != nil):
-    let tmp = LLValue(v: v, storage: s.loc.storage)
-    g.symbols[s.id] = tmp
-    return tmp
-
-  let
-    t = g.llType(s.typ.skipTypes(abstractInst))
-    v = g.m.addGlobal(t, name)
-
-  if sfImportc in s.flags:
-    v.setLinkage(llvm.ExternalLinkage)
-  elif sfExportc in s.flags:
-    v.setLinkage(g.tgtExportLinkage)
-    v.setInitializer(llvm.constNull(t))
-  else:
-    v.setLinkage(g.defaultGlobalLinkage())
-    v.setInitializer(llvm.constNull(t))
-
-  if sfThread in s.flags and optThreads in g.config.globalOptions:
-    v.setThreadLocal(llvm.True)
-  g.debugGlobal(s, v)
-
-  if isConst:
-    v.setGlobalConstant(llvm.True)
-
-  if s.kind in {skLet, skVar, skField, skForVar} and s.alignment > 0:
-    v.setAlignment(cuint s.alignment)
-
-  result = LLValue(v: v, lode: n, storage: s.loc.storage)
-  g.symbols[s.id] = result
-
 proc getUnreachableBlock(g: LLGen): llvm.BasicBlockRef =
   if g.f.unreachableBlock == nil:
     g.f.unreachableBlock = g.b.appendBasicBlockInContext(
@@ -3896,13 +3799,39 @@ proc callCtpop(g: LLGen, v: llvm.ValueRef, size: BiggestInt): llvm.ValueRef =
   g.b.buildCall2(fty, f, [v], g.nn("ctpop", v))
 
 proc callErrno(g: LLGen, prefix: string): llvm.ValueRef =
-  # on linux errno is a function, so we call it here. not at all portable.
+  # depending on the C library, errno will be a function - currently implemented
+  # for glibc and windows
 
   let
     fty = llvm.functionType(g.ptrTy, [])
-    f = g.m.getOrInsertFunction("__" & prefix & "errno_location", fty)
+    f =
+      if g.config.target.targetOS == osWindows:
+        g.m.getOrInsertFunction("_errno", fty)
+      else:
+        g.m.getOrInsertFunction("__" & prefix & "errno_location", fty)
 
   g.b.buildCall2(fty, f, [], g.nn(prefix & "errno"))
+
+proc callIobFunc(g: LLGen, idx: int32): llvm.ValueRef =
+  # stdin/stdout/stderr for msvcrt/ucrt
+
+  let
+    fty = llvm.functionType(g.ptrTy, [g.int32Ty()])
+    f = g.m.getOrInsertFunction("__acrt_iob_func", fty)
+    tmp = g.localAlloca(g.ptrTy, g.nn("crt.tmp"))
+    iob = g.b.buildCall2(fty, f, [g.constInt32(idx)], g.nn("__acrt_iob_func" & $idx))
+
+  discard g.b.buildStore(iob, tmp)
+  tmp
+
+proc callEnviron(g: LLGen): llvm.ValueRef =
+  # _environ for msvcrt/ucrt
+  # TODO arm/msvcrt uses a different name here
+
+  let
+    fty = llvm.functionType(g.ptrTy, [])
+    f = g.m.getOrInsertFunction("__p__environ", fty)
+  g.b.buildCall2(fty, f, [], g.nn("_environ"))
 
 proc callWithOverflow(
     g: LLGen, op: string, a, b: llvm.ValueRef, name: string
@@ -4177,6 +4106,108 @@ proc genObjectInit(g: LLGen, typ: PType, v: llvm.ValueRef, setType: bool) =
         g.genObjectInit(xtyp[i], gep)
   else:
     discard
+
+proc externGlobal(g: LLGen, s: PSym): LLValue =
+  # Extra symbols that the compiler fetches from header files - we'll need
+  # a better solution than hard-coding them, at some point
+  # These are typically "nodecl", "importc" and/or "header" tagged in
+  # the std library
+  let
+    name = g.llName(s)
+    t = g.llType(s.typ)
+  case name
+  of "errno":
+    LLValue(v: g.callErrno(""))
+  of "h_errno":
+    LLValue(v: g.callErrno("h_"))
+  else:
+    if g.config.target.targetOS == osWindows:
+      if name == "stdin":
+        return LLValue(v: g.callIobFunc(0))
+      if name == "stdout":
+        return LLValue(v: g.callIobFunc(1))
+      if name == "stderr":
+        return LLValue(v: g.callIobFunc(2))
+      if name == "_environ":
+        return LLValue(v: g.callEnviron())
+
+    if s.id in g.symbols and not g.interactive():
+      g.symbols[s.id]
+    elif (let v = g.m.getNamedGlobal(name); v != nil):
+      let tmp = LLValue(v: v, storage: s.loc.storage)
+      g.symbols[s.id] = tmp
+      tmp
+    else:
+      let tmp = LLValue(v: g.m.addGlobal(t, name))
+      g.symbols[s.id] = tmp
+      tmp
+
+proc genLocal(g: LLGen, n: PNode): LLValue =
+  let s = n.sym
+  if s.loc.k == locNone:
+    fillLoc(s.loc, locLocalVar, n, s.name.s.mangle.rope, OnStack)
+    if s.kind == skLet:
+      incl(s.loc.flags, lfNoDeepCopy)
+
+  let
+    t = g.llType(s.typ)
+    v = g.localAlloca(t, g.llName(s))
+  g.debugVariable(s, v)
+
+  if s.kind in {skLet, skVar, skField, skForVar} and s.alignment > 0:
+    v.setAlignment(cuint s.alignment)
+
+  let lv = LLValue(v: v, lode: n, storage: s.loc.storage)
+  g.symbols[s.id] = lv
+  lv
+
+proc genGlobal(g: LLGen, n: PNode, isConst: bool): LLValue =
+  let s = n.sym
+
+  if s.id in g.symbols:
+    let
+      name = g.llName(s)
+      t = g.llType(s.typ.skipTypes(abstractInst))
+
+    return g.refGlobal(g.symbols[s.id], name, t)
+
+  if s.loc.k == locNone:
+    fillLoc(s.loc, locGlobalVar, n, g.mangleName(s), if isConst: OnStatic else: OnHeap)
+
+  let name = g.llName(s)
+
+  # Couldn't find by id - should we get by name also? this seems to happen for
+  # stderr for example which turns up with two different id:s.. what a shame!
+  if (let v = g.m.getNamedGlobal(name); v != nil):
+    let tmp = LLValue(v: v, storage: s.loc.storage)
+    g.symbols[s.id] = tmp
+    return tmp
+
+  let
+    t = g.llType(s.typ.skipTypes(abstractInst))
+    v = g.m.addGlobal(t, name)
+
+  if sfImportc in s.flags:
+    v.setLinkage(llvm.ExternalLinkage)
+  elif sfExportc in s.flags:
+    v.setLinkage(g.tgtExportLinkage)
+    v.setInitializer(llvm.constNull(t))
+  else:
+    v.setLinkage(g.defaultGlobalLinkage())
+    v.setInitializer(llvm.constNull(t))
+
+  if sfThread in s.flags and optThreads in g.config.globalOptions:
+    v.setThreadLocal(llvm.True)
+  g.debugGlobal(s, v)
+
+  if isConst:
+    v.setGlobalConstant(llvm.True)
+
+  if s.kind in {skLet, skVar, skField, skForVar} and s.alignment > 0:
+    v.setAlignment(cuint s.alignment)
+
+  result = LLValue(v: v, lode: n, storage: s.loc.storage)
+  g.symbols[s.id] = result
 
 proc supportsMemset(typ: PType): bool =
   supportsCopyMem(typ) and analyseObjectWithTypeField(typ) == frNone
@@ -10417,16 +10448,16 @@ proc genMain(g: LLGen) =
     g.finalize()
 
 proc loadBase(g: LLGen) =
-  let
-    base =
-      g.config.prefixDir.string / "../nlvm-lib/nlvmbase-$1-$2.ll" % [
-        platform.CPU[g.config.target.targetCPU].name,
-        platform.OS[g.config.target.targetOS].name,
-      ]
-    m = parseIRInContext(g.lc, base)
+  let base =
+    g.config.prefixDir.string / "../nlvm-lib/nlvmbase-$1-$2.ll" % [
+      platform.CPU[g.config.target.targetCPU].name,
+      platform.OS[g.config.target.targetOS].name,
+    ]
+  if fileExists(base):
+    let m = parseIRInContext(g.lc, base)
 
-  if g.m.linkModules2(m) != 0:
-    g.config.internalError("module link failed")
+    if g.m.linkModules2(m) != 0:
+      g.config.internalError("module link failed")
 
 proc runOptimizers(g: LLGen) =
   let
@@ -10500,7 +10531,7 @@ proc writeOutput(g: LLGen, project: string) =
 
   g.config.addExternalFileToLink(ofile.AbsoluteFile)
 
-  lllink(g.config)
+  lllink(g.config, g.tm.triple)
 
 proc genForwardedProcs(g: LLGen) =
   # Forward declared proc:s lack bodies when first encountered, so they're given
@@ -10752,10 +10783,10 @@ proc myOpen(graph: ModuleGraph, s: PSym, idgen: IdGenerator): PPassContext =
 
         parseCommandLineOptions(llvmArgs.len.cint, arr, "")
 
-    # Before wasm32 was added as a CPU, we used nlvm.target - this is still
-    # around in some tutorials so leave it around for now - perhaps it makes
-    # sense to try to translate classic target triples to nim targets?
-
+    # If `--nlvm.triple` is set, use that - otherwise, try to construct a triple
+    # from cpu/os options.
+    #
+    # `--nlvm.abi` allows adding an ABI tag, like `musl`, in that case.
     let target = normalizeTargetTriple(
       if graph.config.existsConfigVar("nlvm.target"):
         let
@@ -10764,8 +10795,30 @@ proc myOpen(graph: ModuleGraph, s: PSym, idgen: IdGenerator): PPassContext =
         graph.config.target.setTarget(os, cpu)
         tmp
       else:
-        toTriple(graph.config.target.targetCPU, graph.config.target.targetOS)
+        toTriple(
+          graph.config.target,
+          abi = graph.config.getConfigVar("nlvm.abi", ""),
+          useWasi = graph.config.isDefined("wasi"),
+          isMingw =
+            graph.config.target.targetOS == osWindows and
+            graph.config.cCompiler in {ccGcc, ccLLVM_Gcc, ccClang},
+        )
     )
+
+    if graph.config.target.hostOS != graph.config.target.targetOS or
+        graph.config.target.hostCPU != graph.config.target.targetCPU:
+      # If we're cross-compiling, force `clang` for now
+      if graph.config.cCompiler != ccClang:
+        graph.config.message(
+          s.info, hintUser, "Cross-compiling for " & target & ", switching to clang"
+        )
+
+        graph.config.cCompiler = ccClang
+      else:
+        graph.config.message(s.info, hintUser, "Cross-compiling for " & target)
+
+      graph.config.compileOptionsCmd.add " --target=" & target
+      graph.config.linkOptionsCmd.add " --target=" & target
 
     var tr: llvm.TargetRef
     discard getTargetFromTriple(target, addr(tr), nil)
@@ -10793,3 +10846,4 @@ proc myOpen(graph: ModuleGraph, s: PSym, idgen: IdGenerator): PPassContext =
   g.modules[s.position]
 
 const llgenPass* = makePass(myOpen, myProcess, myClose)
+  # Are we _making_ a shared library

--- a/nlvm/lllink.nim
+++ b/nlvm/lllink.nim
@@ -1,9 +1,8 @@
 import
-  os,
-  osproc,
-  strutils,
+  std/[os, osproc, strformat, strutils, sequtils],
   compiler/[extccomp, lineinfos, msgs, options, platform, pathutils],
-  llvm/llvm
+  llvm/llvm,
+  ./llplatform
 
 iterator passLinkOptions(opts: openArray[string]): string =
   var passNext = false
@@ -38,7 +37,7 @@ iterator passLinkOptions(opts: openArray[string]): string =
 proc findLibraries(s: string): seq[string] =
   for line in s.split('\n'):
     if line.startsWith("libraries: ="):
-      return line["libraries: =".len ..^ 1].split(':')
+      return line["libraries: =".len ..^ 1].split(PathSep).filterIt(it.len > 0)
 
 proc findLastArg(args: openArray[string], opts: openArray[string]): string =
   for i in 1 .. args.len:
@@ -52,56 +51,67 @@ proc findFile(candidates: openArray[string], name: string): string =
       return candidate / name
   ""
 
-proc linkLinuxAmd64(conf: ConfigRef) =
-  # This function emulates clang which emulates gcc which builds on 50 years
-  # of technical debt accumulation in the linker tooling space!
+proc getLinker(conf: ConfigRef, target: string): string =
+  var linkerExe = getConfigVar(conf, conf.cCompiler, ".linkerexe")
+  if linkerExe.len == 0:
+    linkerExe = getLinkerExe(conf, conf.cCompiler)
+  linkerExe = quoteShell(linkerExe)
+  if conf.cCompiler == ccClang and target.len > 0:
+    linkerExe = linkerExe & " --target=" & target
+  linkerExe
 
-  # Ugly hack to reuse nim compiling of C files
-  conf.globalOptions.incl optNoLinking
-  callCCompiler(conf)
-  conf.globalOptions.excl optNoLinking
+proc printSearchDirs(conf: ConfigRef, target: string): seq[string] =
+  try:
+    let driver = conf.getLinker(target)
+    findLibraries(strip(execProcess(&"{driver} --print-search-dirs"))).filterIt(
+      it.len > 0
+    )
+  except CatchableError:
+    @[]
 
-  let filePaths =
-    try:
-      let driver = CC[conf.cCompiler].compilerExe
-      findLibraries(execProcess(driver & " -print-search-dirs"))
-    except CatchableError:
-      @[]
+proc printFileName(conf: ConfigRef, file, target: string): string =
+  try:
+    let driver = conf.getLinker(target)
+    strip(execProcess(&"{driver} --print-file-name={quoteShell(file)}"))
+  except CatchableError:
+    file
 
+proc linkGNU(conf: ConfigRef, target: string) =
+  # This function emulates the clang linker driver which emulates gcc which
+  # builds on 50 years os accumulated technical debt in the linker tooling
+  # space!
+
+  # It is loosely based on `Linker::ConstructJob` for the various platforms,
+  # as found in:
+  # https://github.com/llvm/llvm-project/blob/llvmorg-21.1.8/clang/lib/Driver/ToolChains/Gnu.cpp#L283
+
+  let filePaths = conf.printSearchDirs(target)
   let linkOpts = parseCmdLine(conf.linkOptions) & parseCmdLine(conf.linkOptionsCmd)
 
-  # Simplified version of (ie would need more work):
-  # https://github.com/llvm/llvm-project/blob/llvmorg-15.0.6/clang/lib/Driver/ToolChains/Gnu.cpp#L402
   var args: seq[string]
-
   args.add "ld.lld"
 
   let
+    isLinux = conf.target.targetOS in {osLinux, osAndroid}
     isAndroid = conf.target.targetOS == osAndroid
+    isMips = conf.target.targetCPU in {cpuMips, cpuMipsel, cpuMips64, cpuMips64el}
     pieArg = linkOpts.findLastArg(["-pie", "-no-pie", "-nopie"])
+    # isShared is set when we're creating a static library
+    isShared = optGenDynLib in conf.globalOptions or "-shared" in linkOpts
     isPIE =
       not (
-        "-shared" in linkOpts or "-static" in linkOpts or "-r" in linkOpts or
+        isShared or "-static" in linkOpts or "-r" in linkOpts or
         "-static-pie" in linkOpts
-      ) and pieArg in ["-pie"] # `-pie` by default
+      ) and pieArg in ["-pie"]
     isStaticPIE = "-static-pie" in linkOpts
+    # isStatic is set when dependencies should be linked statically - if isShared
+    # is also set, it means we're creating a shared library whose dependencies
+    # are linked statically
     isStatic = "-static" in linkOpts and not isStaticPIE
     isCpp = optMixedMode in conf.globalOptions
 
-  if isPIE:
-    args.add "-pie"
-
-  if isStaticPIE:
-    args.add ["-static", "-pie", "--no-dynamic-linker", "-z", "text"]
-
-  if "-rdynamic" in linkOpts:
-    args.add ["-export-dynamic"]
-
   if "-s" in linkOpts:
     args.add ["-s"]
-
-  # Next follows a section of distro-specific flags:
-  # https://github.com/llvm/llvm-project/blob/llvmorg-15.0.6/clang/lib/Driver/ToolChains/Linux.cpp#L193
 
   if isAndroid: # TODO or alpine linux
     args.add ["-z", "now"]
@@ -109,29 +119,90 @@ proc linkLinuxAmd64(conf: ConfigRef) =
   if isAndroid: # TODO or suse/ubuntu/alpine linux
     args.add ["-z", "relro"]
 
-  # Ancient distros would need --hash-style=both
-  args.add "--hash-style=gnu"
+  if isLinux and not isMips:
+    # Modern linux uses gnu hash style
+    args.add "--hash-style=gnu"
 
   if isAndroid: # TODO or opensuse
     args.add "--enable-new-dtags"
 
-  # TODO multiarch / multilib
-
   args.add "--eh-frame-hdr"
 
-  args.add ["-m", "elf_x86_64"]
+  # Android ARM/AArch64 use max-page-size=4096 to reduce VMA usage
+  if (conf.target.targetCPU in {cpuArm, cpuArm64}) and isAndroid:
+    args.add ["-z", "max-page-size=4096"]
 
-  if "-shared" in linkOpts:
+  case conf.target.targetCPU
+  of cpuAmd64:
+    args.add ["-m", "elf_x86_64"]
+  of cpuI386:
+    args.add ["-m", "elf_i386"]
+  of cpuArm64:
+    discard
+  of cpuArm:
+    args.add ["-m", "armelf"]
+  of cpuRiscv64:
+    args.add ["-m", "elf64lriscv"]
+    # On some BSDs clang adds an extra -X flag for riscv
+    if conf.target.targetOS in {osNetbsd, osOpenbsd}:
+      args.add "-X"
+  of cpuMips:
+    args.add ["-m", "elf32btsmip"]
+  of cpuMipsel:
+    args.add ["-m", "elf32ltsmip"]
+  of cpuMips64:
+    # prefer 64-bit ABI where available
+    args.add ["-m", "elf64btsmip"]
+  of cpuMips64el:
+    args.add ["-m", "elf64ltsmip"]
+  of cpuPowerpc:
+    args.add ["-m", "elf32ppc"]
+  of cpuPowerpc64, cpuPowerpc64el:
+    args.add ["-m", "elf64ppc"]
+  of cpuSparc:
+    args.add ["-m", "elf32_sparc"]
+  of cpuSparc64:
+    args.add ["-m", "elf64_sparc"]
+  of cpuLoongArch64:
+    discard
+  else:
+    discard
+
+  if isShared:
     args.add "-shared"
 
-  if isStatic:
+  if isStaticPIE:
+    args.add ["-static", "-pie", "--no-dynamic-linker", "-z", "text"]
+  elif isStatic:
     args.add "-static"
-  else:
+  elif "-r" notin linkOpts:
     if "-rdynamic" in linkOpts:
       args.add "-export-dynamic"
 
-    if "-shared" notin linkOpts and not isStaticPIE and "-r" notin linkOpts:
-      args.add ["-dynamic-linker", "/lib64/ld-linux-x86-64.so.2"]
+    if not isShared:
+      if isPIE:
+        args.add "-pie"
+
+      # Per-OS dynamic linker defaults (clang sets these for many toolchains)
+      case conf.target.targetOS
+      of osLinux:
+        case conf.target.targetCPU
+        of cpuAmd64:
+          args.add ["-dynamic-linker", "/lib64/ld-linux-x86-64.so.2"]
+        of cpuI386:
+          args.add ["-dynamic-linker", "/lib/ld-linux.so.2"]
+        of cpuArm64:
+          args.add ["-dynamic-linker", "/lib/ld-linux-aarch64.so.1"]
+        else:
+          discard
+      of osFreebsd:
+        args.add ["-dynamic-linker", "/libexec/ld-elf.so.1"]
+      of osNetbsd:
+        args.add ["-dynamic-linker", "/libexec/ld.elf_so"]
+      of osOpenbsd:
+        args.add ["-dynamic-linker", "/usr/libexec/ld.so"]
+      else:
+        discard
 
   let exeFile = conf.prepareToWriteOutput()
 
@@ -147,12 +218,12 @@ proc linkLinuxAmd64(conf: ConfigRef) =
           "rcrt1.o"
         else:
           "crt1.o"
-      args.add findFile(filePaths, crt1)
+      args.add conf.printFileName(crt1, target)
 
-    args.add findFile(filePaths, "crti.o")
+    args.add conf.printFileName("crti.o", target)
 
     let crtbegin =
-      if "-shared" in linkOpts:
+      if isShared:
         if isAndroid: "crtbegin_so.o" else: "crtbeginS.o"
       elif isStatic:
         if isAndroid: "crtbegin_static.o" else: "crtbeginT.o"
@@ -161,7 +232,8 @@ proc linkLinuxAmd64(conf: ConfigRef) =
       else:
         if isAndroid: "crtbegin_dynamic.o" else: "crtbegin.o"
 
-    args.add findFile(filePaths, crtbegin)
+    args.add conf.printFileName(crtbegin, target)
+
   for opt in linkOpts:
     if opt.startsWith("-L"):
       args.add opt
@@ -171,6 +243,8 @@ proc linkLinuxAmd64(conf: ConfigRef) =
 
   for lib in filePaths:
     args.add "-L" & lib
+
+  args.add "--as-needed"
 
   # Then the project object files...
   for it in conf.externalToLink:
@@ -204,12 +278,13 @@ proc linkLinuxAmd64(conf: ConfigRef) =
       template addRuntimeLibs() =
         if isStatic or isStaticPIE:
           args.add ["-lgcc", "-lgcc_eh"]
-        elif "-shared" in linkOpts:
+        elif isShared:
           args.add "-lgcc_s"
         else:
           args.add ["-lgcc", "--as-needed", "-lgcc_s", "--no-as-needed"]
 
       addRuntimeLibs()
+
       if wantPthread:
         args.add "-lpthread"
 
@@ -222,17 +297,17 @@ proc linkLinuxAmd64(conf: ConfigRef) =
         addRuntimeLibs()
 
     let crtend =
-      if "-shared" in linkOpts:
+      if isShared:
         if isAndroid: "crtend_so.o" else: "crtendS.o"
       elif isPIE or isStaticPIE:
         if isAndroid: "crtend_android.o" else: "crtendS.o"
       else:
         if isAndroid: "crtend_android.o" else: "crtend.o"
 
-    args.add findFile(filePaths, crtend)
+    args.add conf.printFileName(crtend, target)
 
     if not isAndroid:
-      args.add findFile(filePaths, "crtn.o")
+      args.add conf.printFileName("crtn.o", target)
 
   rawMessage(conf, hintLinking, $args)
 
@@ -240,14 +315,191 @@ proc linkLinuxAmd64(conf: ConfigRef) =
     rawMessage(conf, errGenerated, "linking failed")
     quit(1)
 
-proc linkWasm32(conf: ConfigRef) =
+proc last(v: seq[string]): seq[string] =
+  if v.len > 0:
+    @[v[^1]]
+  else:
+    @[]
+
+proc linkMingw(conf: ConfigRef, target: string) =
+  # https://github.com/llvm/llvm-project/blob/llvmorg-21.1.8/clang/lib/Driver/ToolChains/MinGW.cpp#L103
+
+  let
+    filePaths = conf.printSearchDirs(target)
+    linkOpts = parseCmdLine(conf.linkOptions) & parseCmdLine(conf.linkOptionsCmd)
+    isShared = optGenDynLib in conf.globalOptions or "-shared" in linkOpts
+    isCpp = optMixedMode in conf.globalOptions
+
+  var args: seq[string]
+  args.add "ld.lld"
+
+  args.add linkOpts.filterIt(it.startsWith("--sysroot"))
+  args.add linkOpts.filterIt(it == "-s")
+
+  # -m emulation selection
+  case conf.target.targetCPU
+  of cpuI386:
+    args.add ["-m", "i386pe"]
+  of cpuAmd64:
+    args.add ["-m", "i386pep"]
+  of cpuArm:
+    args.add ["-m", "thumb2pe"]
+  of cpuArm64:
+    args.add ["-m", "arm64pe"]
+  else:
+    discard
+
+  # Subsystem
+  if "-mwindows" in linkOpts or optGenGuiApp in conf.globalOptions:
+    args.add ["--subsystem", "windows"]
+  elif "-mconsole" in linkOpts:
+    args.add ["--subsystem", "console"]
+
+  let
+    hasMdll = "-mdll" in linkOpts
+    isStatic = "-static" in linkOpts
+
+  if hasMdll:
+    args.add "--dll"
+  elif isShared:
+    args.add "--shared"
+
+  if isStatic:
+    args.add "-Bstatic"
+  else:
+    args.add "-Bdynamic"
+
+  if hasMdll or isShared:
+    args.add ["-e", "DllMainCRTStartup"]
+    args.add "--enable-auto-image-base"
+
+  for opt in linkOpts:
+    if opt.startsWith("-mguard=") or opt.startsWith("-mguard:"):
+      if opt.contains("none"):
+        args.add "--no-guard-cf"
+      elif opt.contains("cf"):
+        args.add "--guard-cf"
+
+  args.add ["-o", addFileExt(conf.prepareToWriteOutput().string, "exe")]
+
+  # Add startfiles unless requested not to
+  if "-nostdlib" notin linkOpts and "-nostartfiles" notin linkOpts:
+    if hasMdll or isShared:
+      args.add conf.printFileName("dllcrt2.o", target)
+    else:
+      if "-municode" in linkOpts:
+        args.add conf.printFileName("crt2u.o", target)
+      else:
+        args.add conf.printFileName("crt2.o", target)
+    if "-pg" in linkOpts:
+      args.add conf.printFileName("gcrt2.o", target)
+    args.add conf.printFileName("crtbegin.o", target)
+
+  args.add linkOpts.filterIt(it.startsWith("-L"))
+  for lib in filePaths:
+    args.add "-L" & lib
+
+  args.add "--as-needed"
+
+  for it in conf.externalToLink:
+    args.add addFileExt(it, CC[conf.cCompiler].objExt)
+
+  for x in conf.toCompile:
+    args.add x.obj.string
+
+  for opt in passLinkOptions(linkOpts):
+    args.add opt
+
+  for linkedLib in items(conf.cLinkedLibs):
+    args.add parseCmdLine(CC[conf.cCompiler].linkLibCmd % linkedLib.quoteShell)
+  for libDir in items(conf.cLibs):
+    args.add parseCmdLine(join([CC[conf.cCompiler].linkDirCmd, libDir.quoteShell]))
+
+  if "-nostdlib" notin linkOpts and "-r" notin linkOpts:
+    if isCpp:
+      if "-nostdlibxx" notin linkOpts and "-nodefaultlibs" notin linkOpts:
+        if conf.printFileName("libc++.so", target) == "libc++.so" and
+            conf.printFileName("libc++.a", target) == "libc++.a":
+          args.add "-lstdc++"
+        else:
+          args.add "-lc++"
+
+  if "-mthreads" in linkOpts:
+    args.add "-lmingwthrd"
+  args.add "-lmingw32"
+
+  let archName = conf.target.targetCPU.toLLVMArch()
+
+  # TODO we'll have to do something about this: if `gcc` is symlinked to `clang`
+  #      conf.cCompiler will say gcc but we'll actually be using clang libraries
+  #      on windows - at least this seems to hold in the clang64 environment
+  let crt =
+    if isStatic or "-static-libgcc" in linkOpts:
+      [&"libclang_rt.builtins-{archName}.a", "-l:libunwind.a"]
+    elif "-shared-libgcc" in linkOpts:
+      [&"libclang_rt.builtins-{archName}.dll.a", "-l:libunwind.dll.a"]
+    else:
+      [&"libclang_rt.builtins-{archName}.a", "-lunwind"]
+
+  if conf.printFileName(crt[0], target) == crt[0]:
+    # Couldn't find clang_rt? Assume gcc..
+    if isStatic or "-static-libgcc" in linkOpts:
+      args.add ["-lgcc", "-lgcc_eh"]
+    else:
+      args.add ["-lgcc_s", "-lgcc"]
+  else:
+    args.add [conf.printFileName(crt[0], target), crt[1]]
+
+  args.add "-lmoldname"
+  args.add "-lmingwex"
+
+  template isCRT(s: string): bool =
+    s.startsWith("-lmsvcr") or s.startsWith("-lucrt") or s.startsWith("-lcrtdll") or
+      s.startsWith("msvcr") or s.startsWith("ucrt") or s.startsWith("crtdll")
+
+  if not (conf.cLinkedLibs.anyIt(it.isCRT) or linkOpts.anyIt(it.isCRT)):
+    args.add "-lmsvcrt" # TODO default to ucrt? probably
+
+  # user-specified -l flags
+  for linkedLib in items(conf.cLinkedLibs):
+    args.add parseCmdLine(CC[conf.cCompiler].linkLibCmd % linkedLib.quoteShell)
+
+  # system libs
+  if not ("-lwindowsapp" in linkOpts):
+    if ("-mwindows" in linkOpts) or optGenGuiApp in conf.globalOptions:
+      args.add "-lgdi32"
+      args.add "-lcomdlg32"
+    args.add "-ladvapi32"
+    args.add "-lshell32"
+    args.add "-luser32"
+    args.add "-lkernel32"
+
+  # crtend
+  if "-nostdlib" notin linkOpts and "-nostartfiles" notin linkOpts:
+    args.add conf.printFileName("crtend.o", target)
+
+  rawMessage(conf, hintLinking, $args)
+  if not nimLLDLinkMingw(args):
+    rawMessage(conf, errGenerated, "linking failed")
+    quit(1)
+
+proc linkWasm(conf: ConfigRef) =
   var args: seq[string]
 
   args.add "wasm-ld"
 
-  let exeFile = conf.getOutFile(conf.outFile, "wasm")
+  let
+    exeFile = conf.getOutFile(conf.outFile, "wasm")
+    linkOpts = parseCmdLine(conf.linkOptions) & parseCmdLine(conf.linkOptionsCmd)
+    isShared = optGenDynLib in conf.globalOptions or "-shared" in linkOpts
 
-  let linkOpts = parseCmdLine(conf.linkOptions) & parseCmdLine(conf.linkOptionsCmd)
+  args.add ["-m", "wasm32"]
+
+  if "-s" in linkOpts:
+    args.add ["--strip-all"]
+
+  if isShared:
+    args.add ["-shared"]
 
   args.add ["-o", exefile.string]
 
@@ -269,23 +521,130 @@ proc linkWasm32(conf: ConfigRef) =
     rawMessage(conf, errGenerated, "linking failed")
     quit(1)
 
-proc useBuiltinLinker*(conf: ConfigRef): bool =
-  optGenStaticLib notin conf.globalOptions and optGenGuiApp notin conf.globalOptions and
-    optGenDynLib notin conf.globalOptions and
-    conf.getConfigVar("nlvm.linker", "builtin") == "builtin" and
-    conf.cCompiler in {ccGcc, ccLLVM_Gcc, ccCLang} and conf.target.targetOS == osLinux and
-    conf.target.targetCPU == cpuAmd64
+proc linkMSVC(conf: ConfigRef) =
+  # Generic COFF/PE linking using LLD's COFF driver (lld-link)
+  # TODO actually test this - it is loosely based on translating the clang code
 
-proc lllink*(conf: ConfigRef) =
-  let builtinLinker = conf.useBuiltinLinker()
+  var args: seq[string]
+  args.add "lld-link"
 
-  if builtinLinker and conf.target.targetOS == osLinux and
-      conf.target.targetCPU == cpuAmd64:
-    linkLinuxAmd64(conf)
-  elif conf.target.targetCPU == cpuWasm32:
-    linkWasm32(conf)
+  let exeFile = conf.prepareToWriteOutput()
+  # MSVC-style output option
+  args.add "/OUT:" & exefile.string
+
+  # Add object files (.obj or .o depending on compiler)
+  for it in conf.externalToLink:
+    args.add addFileExt(it, CC[conf.cCompiler].objExt)
+  for x in conf.toCompile:
+    args.add x.obj.string
+
+  let linkOpts = parseCmdLine(conf.linkOptions) & parseCmdLine(conf.linkOptionsCmd)
+  echo linkOpts
+  # Basic MSVC-like flags: MACHINE, SUBSYSTEM, DLL/static, optimisation
+  case conf.target.targetCPU
+  of cpuAmd64:
+    args.add "/MACHINE:X64"
+  of cpuI386:
+    args.add "/MACHINE:X86"
+  of cpuArm64:
+    args.add "/MACHINE:ARM64"
   else:
-    # TODO configure this elsewhere? also, -Wl vs raw linker options..:/
-    conf.addLinkOptionCmd("-Wl,--as-needed")
+    discard
 
+  if optGenDynLib in conf.globalOptions:
+    args.add "/DLL"
+
+  # Subsystem: GUI vs console
+  if optGenGuiApp in conf.globalOptions:
+    args.add "/SUBSYSTEM:WINDOWS"
+  else:
+    args.add "/SUBSYSTEM:CONSOLE"
+
+  # Optimize and strip options: when not requesting debug symbols, enable
+  # optimizations similar to clang's MSVC driver.
+  if optCDebug in conf.globalOptions:
+    args.add "/DEBUG"
+  else:
+    args.add "/INCREMENTAL:NO"
+    args.add "/OPT:REF"
+    args.add "/OPT:ICF"
+
+  # Choose default CRT libraries similar to MSVC driver logic.
+  let wantStaticCRT =
+    "/MT" in linkOpts or "/MTd" in linkOpts or "-MT" in linkOpts or "-MTd" in linkOpts or
+    "-static" in linkOpts or conf.isDefined("static")
+
+  if wantStaticCRT:
+    # Static CRT
+    args.add "libcmt.lib"
+    args.add "vcruntime.lib"
+  else:
+    # Dynamic CRT (modern MSVC uses UCRT + VCRUNTIME)
+    args.add "ucrt.lib"
+    args.add "vcruntime.lib"
+
+  # Always add core Windows libraries
+  args.add "kernel32.lib"
+  if optGenGuiApp in conf.globalOptions:
+    args.add "user32.lib"
+
+  # Translate lib dirs and linked libs into COFF-style flags
+  for libDir in items(conf.cLibs):
+    args.add "/LIBPATH:" & $libDir
+
+  for linkedLib in items(conf.cLinkedLibs):
+    let libcmd = CC[conf.cCompiler].linkLibCmd % linkedLib.quoteShell
+    # Try to convert common "-lfoo" into "foo.lib" for COFF
+    if libcmd.startsWith("-l"):
+      let name = libcmd[2 ..^ 1]
+      args.add name & ".lib"
+    else:
+      for part in parseCmdLine(libcmd):
+        args.add part
+
+  for opt in passLinkOptions(
+    parseCmdLine(conf.linkOptions) & parseCmdLine(conf.linkOptionsCmd)
+  ):
+    # Convert -Ldir -> /LIBPATH:dir
+    if opt.startsWith("-L"):
+      args.add "/LIBPATH:" & opt[2 ..^ 1]
+    elif opt.startsWith("-l"):
+      args.add opt[2 ..^ 1] & ".lib"
+    else:
+      args.add opt
+
+  rawMessage(conf, hintLinking, $args)
+  if not nimLLDLinkCoff(args):
+    rawMessage(conf, errGenerated, "linking failed")
+    quit(1)
+
+proc useBuiltinLinker*(conf: ConfigRef): bool =
+  optGenStaticLib notin conf.globalOptions and
+    conf.getConfigVar("nlvm.linker", "builtin") == "builtin"
+
+proc lllink*(conf: ConfigRef, target: string) =
+  if conf.useBuiltinLinker():
+    # Compile {.compile.} files as usual
+    conf.globalOptions.incl optNoLinking
     callCCompiler(conf)
+    conf.globalOptions.excl optNoLinking
+
+    if conf.target.targetCPU == cpuWasm32:
+      linkWasm(conf)
+      return
+
+    if conf.cCompiler in {ccGcc, ccLLVM_Gcc, ccCLang}:
+      if conf.target.targetOS == osWindows:
+        linkMingw(conf, target)
+      else:
+        linkGnu(conf, target)
+      return
+
+    if conf.cCompiler in {ccVcc, ccClangCl}:
+      linkMSVC(conf)
+      return
+
+  # Non-builtin linker fallback
+  if conf.cCompiler in {ccGcc, ccLLVM_Gcc, ccCLang}:
+    conf.addLinkOptionCmd("-Wl,--as-needed")
+  callCCompiler(conf)

--- a/nlvm/llplatform.nim
+++ b/nlvm/llplatform.nim
@@ -1,116 +1,305 @@
 # Translate Nim platform stuff to target triples
-# This is a complete mess.
 
-# See https://github.com/llvm/llvm-project/blob/master/llvm/include/llvm/ADT/Triple.h
+# See https://github.com/llvm/llvm-project/blob/main/llvm/lib/TargetParser/Triple.cpp
 # for some insight into how llvm deals with it..
 
 import compiler/platform
 
 import strutils
 
-# couldn't find those marked with ? in llvm targets..
-# the first option will be used for output, but parsing will try all..
-const
-  cpuNames: array[TSystemCPU, seq[string]] = [
-    @["unknown"],
-    @["i386", "i486", "i586", "i686"],
-    @["m68k"], # ?
-    @["alpha"], # ?
-    @["powerpc"],
-    @["powerpc64"],
-    @["powerpc64le"],
-    @["sparc"],
-    @["vm"], # ?
-    @["hppa"], # ?
-    @["ia64"], # ?
-    @["x86_64", "amd64"],
-    @["mips"],
-    @["mips64el"],
-    @["arm"],
-    @["aarch64"],
-    @["js"], # ? emscripten maybe?
-    @["nimvm"], # ?
-    @["avr"],
-    @["msp430"],
-    @["sparc64"], # ?
-    @["mips64"],
-    @["mips64el"],
-    @["riscv32"],
-    @["riscv64"],
-    @["esp"],
-    @["wasm32"],
-    @["e2k"],
-    @["loongarch64"],
-  ]
-  osNames: array[TSystemOS, seq[string]] = [
-    @["unknown"],
-    @["dos"], # ?
-    @["windows"],
-    @["os2"], # ?
-    @["linux"],
-    @["morphos"], # ?
-    @["skyos"], # ?
-    @["solaris"],
-    @["irix"],
-    @["netbsd"],
-    @["freebsd"],
-    @["openbsd"],
-    @["dragonfly"],
-    @["crossos"], # ?
-    @["aix"],
-    @["palmos"], # ?
-    @["qnx"], # ?
-    @["amiga"], # ?
-    @["atari"], # ?
-    @["netware"], # ?
-    @["macos"], # ? how to disambiguate with osx?
-    @["macos"],
-    @["ios"], # ?
-    @["haiku"],
-    @["android"], # ?
-    @["vxworks"], # ?
-    @["genode"], # ?
-    @["js"], # ?
-    @["nimvm"], # ?
-    @["unknown"], # ?
-    @["nintendoswitch"], # ?,
-    @["freertos"], # ?,
-    @["zephyr"], # ?
-    @["nuttx"], # ?
-    @["any"],
-  ]
+proc toLLVMArch*(cpu: TSystemCPU): string =
+  case cpu
+  of cpuNone: "unknown"
+  of cpuI386: "i386"
+  of cpuAmd64: "x86_64"
+  of cpuArm: "arm"
+  of cpuArm64: "aarch64"
+  of cpuMips: "mips"
+  of cpuMipsel: "mipsel"
+  of cpuMips64: "mips64"
+  of cpuMips64el: "mips64el"
+  of cpuRiscV32: "riscv32"
+  of cpuRiscV64: "riscv64"
+  of cpuWasm32: "wasm32"
+  of cpuLoongArch64: "loongarch64"
+  of cpuPowerpc: "powerpc"
+  of cpuPowerpc64: "powerpc64"
+  of cpuPowerpc64el: "powerpc64le"
+  of cpuSparc: "sparc"
+  of cpuSparc64: "sparc64"
+  of cpuAVR: "avr"
+  of cpuIa64: "ia64"
+  of cpuM68k: "m68k"
+  of cpuAlpha: "alpha"
+  of cpuVm: "vm"
+  of cpuHppa: "hppa"
+  of cpuE2k: "e2k"
+  of cpuEsp: "xtensa"
+  of cpuJS: "js"
+  of cpuNimVM: "nimvm"
+  of cpuMSP430: "msp430"
 
-proc toTriple*(cpu: TSystemCPU, os: TSystemOS): string =
-  # In most cases, we'll just use the string from above, but there are plenty
-  # of unknowns and some special cases where we'll just randomly pick something
-  # - this needs upstream fixes
+proc toTriple*(
+    t: Target,
+    abi: string = "",
+    useWasi: bool = false,
+    isMingw: bool = false,
+    libc: string = "",
+): string =
+  ## Return a reasonable LLVM target triple for `t`.
+  ##
+  ## `abi` may be used to request alternate ABIs (e.g. "musl", "gnu",
+  ## "wasi", "android", "mingw"). The boolean flags are provided as
+  ## helpers for callers that have explicit booleans. If `abi` is set it
+  ## takes precedence over `libc` and the boolean flags.
+  let arch = toLLVMArch(t.targetCPU)
 
-  if cpu == cpuArm and os == osLinux:
-    "arm-linux-gnueabihf" # assume rpi3
-  elif cpu == cpuAmd64 and os == osLinux:
-    "x86_64-unknown-linux-gnu" # distro missing! what about c library?
+  var vendor = "unknown"
+  var osPart = "unknown-unknown"
+  let a = (if abi.len > 0: abi else: libc).toLowerAscii()
+  let wantWasi = useWasi or a == "wasi"
+  let wantMingw = isMingw or a == "mingw" or a == "gnu"
+  case t.targetOS
+  of osLinux:
+    if a.len > 0:
+      osPart = "linux-" & a
+    else:
+      osPart = "linux-gnu"
+  of osAndroid:
+    osPart = "linux-android"
+  of osMacosx, osMacos:
+    vendor = "apple"
+    osPart = "darwin"
+  of osIos:
+    vendor = "apple"
+    osPart = "ios"
+  of osWindows:
+    vendor = "pc"
+    if wantMingw:
+      osPart = "windows-gnu"
+    else:
+      osPart = "windows-msvc"
+  of osFreebsd:
+    osPart = "freebsd"
+  of osOpenbsd:
+    osPart = "openbsd"
+  of osNetbsd:
+    osPart = "netbsd"
+  of osDragonfly:
+    osPart = "dragonfly"
+  of osSolaris:
+    osPart = "solaris"
+  of osAix:
+    osPart = "aix"
+  of osHaiku:
+    osPart = "haiku"
+  of osVxWorks:
+    osPart = "vxworks"
+  of osGenode:
+    osPart = "unknown-elf"
+  of osJS:
+    # JS hosting: prefer WASM/WASI if requested
+    if wantWasi:
+      return "wasm32-unknown-wasi"
+    osPart = "unknown-unknown"
+  of osNintendoSwitch:
+    osPart = "unknown-elf"
+  of osFreeRTOS, osZephyr, osNuttX:
+    osPart = "unknown-elf"
+  of osAny:
+    osPart = "unknown-unknown"
   else:
-    cpuNames[cpu][0] & "-unknown-" & osNames[os][0]
+    osPart = "unknown-unknown"
+
+  # Special-case wasm: support wasi if requested.
+  if arch == "wasm32":
+    if wantWasi:
+      return "wasm32-unknown-wasi"
+    # Default wasm target
+    return "wasm32-unknown-unknown"
+
+  arch & "-" & vendor & "-" & osPart
 
 proc parseTarget*(target: string): tuple[cpu: TSystemCPU, os: TSystemOS] =
-  let t = target.normalize()
-  if t == "arm-linux-gnueabihf":
-    (cpuArm, osLinux)
+  ## Parse a target triple (or short triple) and return the corresponding
+  ## `TSystemCPU` and `TSystemOS`. This attempts to recognize the same
+  ## architectures and OS names used by `toTriple`.
+  var s = target.toLowerAscii()
+
+  # Split components of the triple (arch-vendor-os-environment)
+  let parts = s.split('-')
+  var archTok =
+    if parts.len > 0:
+      parts[0]
+    else:
+      s
+
+  var cpu = cpuNone
+  var os = osAny
+  case archTok
+  of "x86_64", "amd64":
+    cpu = cpuAmd64
+  of "i386", "i486", "i586", "i686":
+    cpu = cpuI386
+  of "aarch64", "arm64":
+    cpu = cpuArm64
+  of "arm":
+    cpu = cpuArm
+  of "powerpc64le", "ppc64le":
+    cpu = cpuPowerpc64el
+  of "powerpc64", "ppc64":
+    cpu = cpuPowerpc64
+  of "powerpc", "ppc":
+    cpu = cpuPowerpc
+  of "mips64el":
+    cpu = cpuMips64el
+  of "mips64":
+    cpu = cpuMips64
+  of "mipsel":
+    cpu = cpuMipsel
+  of "mips":
+    cpu = cpuMips
+  of "riscv64":
+    cpu = cpuRiscV64
+  of "riscv32":
+    cpu = cpuRiscV32
+  of "wasm", "wasm32", "wasm64":
+    cpu = cpuWasm32
+  of "loongarch64":
+    cpu = cpuLoongArch64
+  of "sparc64":
+    cpu = cpuSparc64
+  of "sparc":
+    cpu = cpuSparc
+  of "ia64", "itanium":
+    cpu = cpuIa64
+  of "avr":
+    cpu = cpuAVR
+  of "msp430":
+    cpu = cpuMSP430
+  of "xtensa", "esp":
+    cpu = cpuEsp
+  of "e2k":
+    cpu = cpuE2k
+  of "hppa":
+    cpu = cpuHppa
+  of "alpha":
+    cpu = cpuAlpha
+  of "m68k":
+    cpu = cpuM68k
+  of "js":
+    cpu = cpuJS
+  of "nimvm":
+    cpu = cpuNimVM
   else:
-    var
-      cpu = cpuNone
-      os = osStandalone
+    # Try looser substring matches over the whole triple.
+    if s.contains("x86_64") or s.contains("amd64"):
+      cpu = cpuAmd64
+    elif s.contains("i386"):
+      cpu = cpuI386
+    elif s.contains("arm64") or s.contains("aarch64"):
+      cpu = cpuArm64
+    elif s.contains("arm"):
+      cpu = cpuArm
+    elif s.contains("powerpc64le") or s.contains("ppc64le"):
+      cpu = cpuPowerpc64el
+    elif s.contains("powerpc64") or s.contains("ppc64"):
+      cpu = cpuPowerpc64
+    elif s.contains("powerpc") or s.contains("ppc"):
+      cpu = cpuPowerpc
+    elif s.contains("mips64el"):
+      cpu = cpuMips64el
+    elif s.contains("mips64"):
+      cpu = cpuMips64
+    elif s.contains("mipsel"):
+      cpu = cpuMipsel
+    elif s.contains("mips"):
+      cpu = cpuMips
+    elif s.contains("riscv64"):
+      cpu = cpuRiscV64
+    elif s.contains("riscv32"):
+      cpu = cpuRiscV32
+    elif s.contains("wasm"):
+      cpu = cpuWasm32
+    elif s.contains("loongarch"):
+      cpu = cpuLoongArch64
 
-    for xcpu, names in cpuNames:
-      for name in names:
-        if t.startsWith(name):
-          cpu = xcpu
+  # Determine OS by looking at later components and common tokens.
+  for i in 1 .. parts.len - 1:
+    let p = parts[i]
+    case p
+    of "linux":
+      os = osLinux
+    of "android":
+      os = osAndroid
+    of "darwin", "macos":
+      os = osMacosx
+    of "ios":
+      os = osIos
+    of "windows", "mingw32", "mingw", "win32":
+      os = osWindows
+    of "freebsd":
+      os = osFreebsd
+    of "openbsd":
+      os = osOpenbsd
+    of "netbsd":
+      os = osNetbsd
+    of "dragonfly":
+      os = osDragonfly
+    of "solaris", "sunos":
+      os = osSolaris
+    of "aix":
+      os = osAix
+    of "vxworks":
+      os = osVxWorks
+    of "haiku":
+      os = osHaiku
+    of "wasi":
+      # wasm+wasi maps to wasm CPU and JS-like OS
+      cpu = cpuWasm32
+      os = osJS
+    else:
+      # no direct match in this part; continue to next part
+      continue
 
-    for xos, names in osNames:
-      # TODO keeps looping because later names seem more recent, but this needs
-      #      verifying.. "contains" is a bit too lax
-      for name in names:
-        if t.contains(name):
-          os = xos
+  # If arch token indicates wasm, ensure CPU is set.
+  if (archTok == "wasm" or archTok == "wasm32" or archTok == "wasm64") and cpu == cpuNone:
+    cpu = cpuWasm32
 
-    (cpu, os)
+  return (cpu, os)
+
+when isMainModule:
+  let cases = [
+    (cpuAmd64, osLinux, ""),
+    (cpuArm, osLinux, ""),
+    (cpuAmd64, osWindows, "mingw"),
+    (cpuWasm32, osJS, "wasi"),
+    (cpuArm64, osMacosx, ""),
+    (cpuI386, osNetbsd, ""),
+    (cpuLoongArch64, osLinux, ""),
+    (cpuRiscV64, osLinux, ""),
+    (cpuPowerpc64el, osLinux, ""),
+    (cpuMips64el, osLinux, ""),
+  ]
+
+  for c in cases:
+    var T: Target
+    T.setTarget(c[1], c[0])
+    let abi = c[2]
+    let triple =
+      if abi.len > 0:
+        toTriple(T, abi = abi)
+      else:
+        toTriple(T)
+    let (cpu2, os2) = parseTarget(triple)
+    assert(
+      cpu2 == T.targetCPU,
+      "cpu round-trip failed: " & triple & " -> " & $cpu2 & " (want " & $T.targetCPU &
+        ")",
+    )
+    assert(
+      os2 == T.targetOS,
+      "os round-trip failed: " & triple & " -> " & $os2 & " (want " & $T.targetOS & ")",
+    )
+
+  echo "llplatform.nim: round-trip tests passed"

--- a/nlvm/nim.cfg
+++ b/nlvm/nim.cfg
@@ -9,8 +9,15 @@ passL:"-lpthread"
 
 define:nimcore
 --warning[CStringConv]:off
+--dynlibOverrideAll
+
+@if windows:
+  passl:"-Wl,--stack=16777216"
+@end
 
 @if staticLLVM:
   cc=clang
+  @if windows:
+    passl:"-static"
+  @end
 @end
-

--- a/nlvm/nlvm.nim
+++ b/nlvm/nlvm.nim
@@ -2,29 +2,29 @@
 # Copyright (c) Jacek Sieka 2016-2019
 # See the LICENSE file for license info (doh!)
 
-import std/[browsers, sequtils, parseopt, strutils, times, os]
-
-import "."/llgen, llvm/llvm
-
 import
+  std/[browsers, sequtils, parseopt, strutils, times, os],
+  llvm/llvm,
   compiler/[
     ast, cmdlinehelper, commands, condsyms, extccomp, idents, lexer, lineinfos,
     llstream, modulegraphs, modules, msgs, options, passes, passaux, pathutils, platform,
-  ]
+  ],
+  ./llgen
+
 proc semanticPasses(g: ModuleGraph) =
   registerPass g, verbosePass
   registerPass g, semPass
 
 const
-  NlvmVersion = "0.0.1"
+  NlvmVersion = "0.0.2"
   NlvmHash = gorge("git rev-parse HEAD").strip
   NimHash = gorge("git -C ../Nim rev-parse HEAD").strip
 
   HelpHeader =
     """nlvm compiler for Nim, version $1 [$2: $3]
 
-Copyright (c) 2015-2019 Jacek Sieka
-Nim compiler (c) 2009-2019 Andreas Rumpf
+Copyright (c) 2015-2026 Jacek Sieka
+Nim compiler (c) 2009-2026 Andreas Rumpf
 """
 
 const
@@ -387,8 +387,6 @@ let
   conf = newConfigRef()
   cache = newIdentCache()
 
-# We accept many clang options in `passc` so why not
-conf.cCompiler = ccCLang
 conf.prefixDir = AbsoluteDir(tmp / "Nim")
 conf.searchPaths.insert(conf.prefixDir / RelativeDir"../nlvm-lib", 0)
 

--- a/skipped-tests.txt
+++ b/skipped-tests.txt
@@ -180,7 +180,6 @@ tests/stdlib/tjson.nim c
 tests/stdlib/tjson.nim cpp --backend:cpp
 tests/stdlib/tjson.nim js --backend:js --jsbigint64:off -d:nimStringHash2
 tests/stdlib/tjson.nim js --backend:js --jsbigint64:on
-tests/stdlib/tlwip.nim c
 tests/stdlib/tmath.nim c
 tests/stdlib/tmath.nim c -d:danger
 tests/stdlib/tmath.nim c --mm:refc


### PR DESCRIPTION
This one turned out to be a lot easier than anticipated!

As it happens, the existing code is already perfectly well capable of compiling things on windows and all that's needed is a bit of patching and plumbing on the linking side and voila, it just works.

The setup, as tested by CI, uses mingw (plausibly it could be extended to msvc as well, but why?) to provide the compiler runtime and the Windows support libraries needed to link, but otherwise just works out of the box, and the binaries produced are fully stand-alone (apart from the usual Windows DLL dependencies).

* Improve target triple handling - the "just works" thing might actually carry over to all platforms llvm supports, meaning that flags like `--cpu:arm64` will do the right thing - tests needed to verify this
* Add support for cross-compiling to windows using `llvm-mingw` as the recommended windows environment
* In theory, it should be easy to support an msvc build environment as well using something like [xwin](https://github.com/Jake-Shadle/xwin) to fetch the windows SDK - tests and documentation needed

The way compilation is set up, `nlvm` will compile the Nim code as usual and then invoke the built-in `lld` linker to link an executable.

To link, `lld` needs either `.dll` or `.lib` files for each shared library used by the application - the C and windows system libraries in particular (`msvcrt`, `kernel32` etc). Linking minics what `clang` would do.

We also need a compiler runtime library - this is taken from the existing C compiler setup, meaning `libgcc` for `gcc` and `compiler-rt`/`libunwind` for `clang`.

When cross-compiling, the same thing applies but we'll now also use `clang` to find the support libraries for the target environment, so clang needs to be compiled in such a way to find the installed mingw32-w64 environment - the easiest thing to do is to just download llvm-mingw and put it first in the PATH.