### PR TITLE
fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,9 +91,9 @@ run-testament-noskip: $(NLVMR) lib/nim/testament/testament$(EXE)
 test: run-testament
 	@-make stats
 
+# Output suitable for sticking into skipped-tests.txt (with classification comments)
+# duplicate entries are merged by the classifier
 update-skipped: run-testament-noskip
-	# Output suitable for sticking into skipped-tests.txt (with classification comments)
-	# duplicate entries are merged by the classifier
 	@-jq -s '[.[][]|select(.result != "reSuccess" and .result != "reDisabled")]' lib/nim/testresults/*.json \
 	  | jq -f classify-errors.jq \
 	  | jq -r '.[] | "\(.name) # \(.classification) / \(.result)"' | sort > skipped-tests.txt

--- a/lib/nlvm/nlvm_system.nim
+++ b/lib/nlvm/nlvm_system.nim
@@ -12,6 +12,8 @@
 
 # Nothing in here may raise
 {.push raises: [].}
+{.push checks: off.}
+
 {.used.}
 import system/ansi_c
 import ./nlvm_unwind
@@ -42,9 +44,9 @@ const
 # Need these for the runtime type information
 include system/inclrtl, system/hti
 
-template dprintf(s: cstring, x: varargs[untyped]) =
+template dprintf(body: varargs[untyped]) =
   when defined(nlvmDebugSystem):
-    c_printf(s, x)
+    c_printf(body)
   else:
     discard
 
@@ -62,8 +64,6 @@ type
     ## data is placed last, allowing us to add fields at the beginning of this
     ## struct without breaking ABI - in nlvm, this is not strictly necessary
     ## because we don't support an ABI yet, but might as well prepare :)
-    ## TODO technically, we could be allocating this memory together with the
-    ##      memory for the nimException, instead of keeping a ref here!
     nimException: ref Exception
     nextException: ptr UnwindException
     handlerCount: int
@@ -117,7 +117,7 @@ func readUleb128(v: var pointer): uint64 =
   ## Read unsigned variable-length integer - no error checking
   var shift: uint
 
-  while true:
+  while shift < 64:
     let b = v.readBytes(uint8)
     result = result or (uint64(b and 0x7F) shl shift)
     shift += 7
@@ -131,7 +131,7 @@ func readSleb128(v: var pointer): int64 =
     res: uint64
     b: uint8
 
-  while true:
+  while shift < 64:
     b = v.readBytes(uint8)
     res = res or (uint64(b and 0x7F) shl shift)
     shift += 7
@@ -206,40 +206,43 @@ proc readEncodedPointer(v: var pointer, ctx: UnwindContext, encoding: uint8): po
 func getThrownObjectPtr(e: ptr UnwindException): pointer =
   cast[pointer](e).offset(sizeof(UnwindException))
 
-proc toUnwindException(e: ptr NlvmException): ptr UnwindException =
+func toUnwindException(e: ptr NlvmException): ptr UnwindException =
   addr e.unwindException
 
 func toNlvmException(e: ptr UnwindException): ptr NlvmException =
-  cast[ptr NlvmException](cast[uint](e) + sizeof(UnwindException).uint -
-    sizeof(NlvmException).uint)
+  cast[ptr NlvmException](cast[uint](e) - NlvmException.offsetOf(unwindException).uint)
 
-func toNimException(e: ptr NlvmException): ref Exception =
-  e[].nimException
+proc destroy(e: ptr NlvmException) =
+  # We must manually clear any managed memory from `NlvmExceptiuon` before
+  # freeing the C memory
+  when declared(GC_unref):
+    GC_unref(e[].nimException)
 
-func toNimException(e: ptr UnwindException): ref Exception =
-  e.toNlvmException().toNimException()
+  e[].nimException = nil
+  c_free(e)
 
 proc nlvmExceptionCleanup(
     unwindCode: UnwindReasonCode, exception: ptr UnwindException
 ) {.cdecl.} =
   dprintf("Cleanup %p\n", exception)
-  let nlvme = toNlvmException(exception)
-  when declared(GC_unref):
-    GC_unref(nlvme.nimException)
-  c_free(cast[pointer](nlvme))
+  destroy(toNlvmException(exception))
 
 var ehGlobals {.threadvar.}: NlvmEhGlobals
 
-include system/rawquits
-proc unhandledException() {.noreturn.} =
-  c_fprintf(cstderr, "Error: unhandled exception: [foreign]\n")
+proc unhandledException(e: ptr UnwindException) {.noreturn.} =
+  discard c_fflush(cstdout)
+  if e[].isNative():
+    let e = e.toNlvmException()
+    c_fprintf(
+      cstderr,
+      "Error: unhandled exception: %s [%s]\n",
+      cstring(e[].nimException.msg),
+      e[].nimException.name,
+    )
+  else:
+    c_fprintf(cstderr, "Error: unhandled exception: [foreign]\n")
 
-  rawQuit(1) # TODO alternatively, quitOrDebug
-
-proc unhandledException(e: ref Exception) {.noreturn.} =
-  c_fprintf(cstderr, "Error: unhandled exception: %s [%s]\n", cstring(e.msg), e.name)
-
-  rawQuit(1) # TODO alternatively, quitOrDebug
+  c_abort()
 
 func getNimTypePtr(
     ttypeIndex: int, classInfo: pointer, ttypeEncoding: uint8, ctx: UnwindContext
@@ -268,7 +271,7 @@ when defined(nimV2):
       align: int16
       depth: int16
       display: ptr UncheckedArray[uint32] # classToken
-      when defined(nimTypeNames) or defined(nimArcIds):
+      when defined(nimTypeNames) or defined(nimArcIds) or defined(nimOrcLeakDetector):
         name: cstring
       traceImpl: pointer
       typeInfoV1: pointer # for backwards compat, usually nil
@@ -284,7 +287,7 @@ when defined(nimV2):
   func exceptionType(e: ref Exception): PNimTypeV2 =
     # return the dynamic type of an exception, which nlvm stores at the beginning
     # of the object
-    cast[ptr PNimTypeV2](unsafeAddr e[])[]
+    cast[ptr PNimTypeV2](addr e[])[]
 
   func getNimType(
       ttypeIndex: int, classInfo: pointer, ttypeEncoding: uint8, ctx: UnwindContext
@@ -302,43 +305,43 @@ else:
   func exceptionType(e: ref Exception): PNimType =
     # return the dynamic type of an exception, which nlvm stores at the beginning
     # of the object
-    cast[ptr PNimType](unsafeAddr e[])[]
+    cast[ptr PNimType](addr e[])[]
 
   func getNimType(
       ttypeIndex: int, classInfo: pointer, ttypeEncoding: uint8, ctx: UnwindContext
   ): PNimType =
     cast[PNimType](getNimTypePtr(ttypeIndex, classInfo, ttypeEncoding, ctx))
 
-import system/memory
+proc raiseOrAbort(unwindException: ptr UnwindException) {.noreturn.} =
+  let reason = raiseException(unwindException)
 
-proc nlvmRaise(e: ref Exception) {.compilerproc, noreturn.} =
+  if reason != URC_END_OF_STACK:
+    # "shouldn't happen"
+    c_fprintf(cstderr, "Error: cannot raise exception: %d\n", reason)
+    c_abort()
+
+  unhandledException(unwindException) # noreturn
+
+proc nlvmRaise(e: sink ref Exception) {.compilerproc, noreturn.} =
   const esize = csize_t(sizeof NlvmException)
-  let excMem = c_malloc(esize)
-  nimZeroMem(excMem, esize)
-  let exc = cast[ptr NlvmException](excMem)
+  let exc = cast[ptr NlvmException](c_calloc(1, esize))
 
-  exc.unwindException.exceptionClass = nlvmExceptionClass
-  exc.unwindException.exceptionCleanup = nlvmExceptionCleanup
-  exc.nimException = e
+  exc[].unwindException.exceptionClass = nlvmExceptionClass
+  exc[].unwindException.exceptionCleanup = nlvmExceptionCleanup
 
   # Help keep Nim exception around
-  when declared(GC_ref): # But only when using gc!
+  when declared(GC_ref):
     dprintf("gcref %p\n", addr e[])
     GC_ref(e)
 
   let unwindException = exc.toUnwindException()
   dprintf("Raising %s %p %p\n", cstring(e.name), unwindException, e.exceptionType())
 
-  let reason = raiseException(unwindException)
-
-  case reason
-  of URC_END_OF_STACK:
-    unhandledException(e)
-  else:
-    # "shouldn't happen"
-    c_fprintf(cstderr, "Error: cannot raise exception: %d\n", reason)
-
-  c_abort()
+  # Make sure that we've done all the ORC/ARC refcounting before `raiseException`
+  # since `raiseOrAbort` will not return and the nim-injected destructor only
+  # runs at the end of the scope
+  exc[].nimException = ensureMove(e)
+  raiseOrAbort(exc.toUnwindException())
 
 proc nlvmReraise() {.compilerproc, noreturn.} =
   if not ehGlobals.closureException.isNil:
@@ -353,23 +356,12 @@ proc nlvmReraise() {.compilerproc, noreturn.} =
 
   if unwindException[].isNative():
     let exceptionHeader = unwindException.toNlvmException()
+    dprintf("Reraise native %p %d\n", unwindException, cint(exceptionHeader.handlerCount))
     exceptionHeader.handlerCount = -exceptionHeader.handlerCount
   else:
+    dprintf("Reraise foreign %p", unwindException)
     ehGlobals.caughtExceptions = nil
-
-  let reason = raiseException(unwindException)
-
-  case reason
-  of URC_END_OF_STACK:
-    if unwindException[].isNative():
-      unhandledException(unwindException.toNimException())
-    else:
-      unhandledException()
-  else:
-    # "shouldn't happen"
-    c_fprintf(cstderr, "Error: cannot reraise exception: %d\n", reason)
-
-  c_abort()
+  raiseOrAbort(unwindException)
 
 proc nlvmSetClosureException(e: ref Exception) {.compilerproc.} =
   dprintf "set clo: %p\n", addr e[]
@@ -385,7 +377,7 @@ proc nlvmGetCurrentException(): ref Exception {.compilerproc.} =
     if unwindException.isNil():
       nil
     else:
-      unwindException.toNimException()
+      unwindException.toNlvmException()[].nimException
 
 proc nlvmGetCurrentExceptionMsg(): string {.compilerproc.} =
   let e = nlvmGetCurrentException()
@@ -406,7 +398,7 @@ proc nlvmBeginCatch(unwindArg: pointer) {.compilerproc.} =
 
   if unwindException[].isNative():
     let exceptionHeader = unwindException.toNlvmException()
-    dprintf("begin native %d\n", exceptionHeader.handlerCount)
+    dprintf("begin native %d\n", cint(exceptionHeader.handlerCount))
     exceptionHeader.handlerCount =
       if exceptionHeader.handlerCount < 0:
         -exceptionHeader.handlerCount +% 1
@@ -435,7 +427,7 @@ proc nlvmEndCatch() {.compilerproc.} =
 
   if unwindException[].isNative():
     let exceptionHeader = unwindException.toNlvmException()
-    dprintf("end native %d\n", exceptionHeader.handlerCount)
+    dprintf("end native %d\n", cint(exceptionHeader.handlerCount))
     if exceptionHeader.handlerCount < 0:
       # Rethrowing
       exceptionHeader.handlerCount = exceptionHeader.handlerCount +% 1
@@ -448,12 +440,7 @@ proc nlvmEndCatch() {.compilerproc.} =
       if exceptionHeader.handlerCount == 0:
         ehGlobals.caughtExceptions = exceptionHeader.nextException
 
-        when declared(GC_unref):
-          let e = exceptionHeader.toNimException()
-          dprintf("gcunref %p\n", addr e[])
-          GC_unref(e)
-
-        c_free(toNlvmException(unwindException))
+        destroy(exceptionHeader)
   else:
     deleteException(ehGlobals.caughtExceptions)
     ehGlobals.caughtExceptions = nil
@@ -735,4 +722,5 @@ proc nlvmEHPersonality(
   else:
     URC_FATAL_PHASE1_ERROR
 
+{.pop.}
 {.pop.}

--- a/llvm/llvm.nim
+++ b/llvm/llvm.nim
@@ -347,9 +347,10 @@ proc dIBuilderCreateFunction*(
     flags: cuint,
     isOptimized: bool,
 ): MetadataRef =
+  let flags = cast[DIFlags](flags)
   dIBuilderCreateFunction(
     d, scope, name.cstring, name.clen, linkageName.cstring, linkageName.clen, file,
-    lineNo, ty, isLocalToUnit.Bool, isDefinition.Bool, scopeLine, flags.DIFlags,
+    lineNo, ty, isLocalToUnit.Bool, isDefinition.Bool, scopeLine, flags,
     isOptimized.Bool,
   )
 
@@ -382,10 +383,11 @@ proc dIBuilderCreateStructType*(
     vtableHolder: MetadataRef,
     uniqueId: string,
 ): MetadataRef =
+  let flags = cast[DIFlags](flags)
   dIBuilderCreateStructType(
-    d, scope, name.cstring, name.clen, file, lineNumber, sizeBits, alignBits,
-    flags.DIFlags, derivedFrom, elements.oaAddr, elements.oaLen, runtimeLang,
-    vtableHolder, uniqueId.cstring, uniqueId.clen,
+    d, scope, name.cstring, name.clen, file, lineNumber, sizeBits, alignBits, flags,
+    derivedFrom, elements.oaAddr, elements.oaLen, runtimeLang, vtableHolder,
+    uniqueId.cstring, uniqueId.clen,
   )
 
 proc dIBuilderCreateMemberType*(
@@ -400,9 +402,10 @@ proc dIBuilderCreateMemberType*(
     flags: cuint,
     ty: MetadataRef,
 ): MetadataRef =
+  let flags = cast[DIFlags](flags)
   dIBuilderCreateMemberType(
     d, scope, name.cstring, name.clen, file, lineNo, sizeBits, alignBits, offsetBits,
-    flags.DIFlags, ty,
+    flags, ty,
   )
 
 proc dIBuilderCreateGlobalVariableExpression*(
@@ -434,9 +437,10 @@ proc dIBuilderCreateAutoVariable*(
     flags: cuint,
     alignBits: uint32,
 ): MetadataRef =
+  let flags = cast[DIFlags](flags)
   dIBuilderCreateAutoVariable(
-    d, scope, name.cstring, name.clen, file, lineNo, ty, alwaysPreserve.Bool,
-    flags.DIFlags, alignBits,
+    d, scope, name.cstring, name.clen, file, lineNo, ty, alwaysPreserve.Bool, flags,
+    alignBits,
   )
 
 proc dIBuilderCreateParameterVariable*(
@@ -450,9 +454,10 @@ proc dIBuilderCreateParameterVariable*(
     alwaysPreserve: bool,
     flags: cuint,
 ): MetadataRef =
+  let flags = cast[DIFlags](flags)
   dIBuilderCreateParameterVariable(
     d, scope, name.cstring, name.clen, argNo, file, lineNo, ty, alwaysPreserve.Bool,
-    flags.DIFlags,
+    flags,
   )
 
 proc dIBuilderCreateArrayType*(

--- a/nlvm/llgen.nim
+++ b/nlvm/llgen.nim
@@ -305,9 +305,6 @@ template int1Ty(g: LLGen): llvm.TypeRef =
 template int8Ty(g: LLGen): llvm.TypeRef =
   g.lc.int8TypeInContext()
 
-template int16Ty(g: LLGen): llvm.TypeRef =
-  g.lc.int16TypeInContext()
-
 template int32Ty(g: LLGen): llvm.TypeRef =
   g.lc.int32TypeInContext()
 
@@ -1888,7 +1885,7 @@ proc llType(g: LLGen, typ: PType, deep = true): llvm.TypeRef =
     g.primitives[typ.kind]
   of tyGenericBody, tyGenericInst, tyGenericInvocation, tyGenericParam, tyDistinct,
       tyOrdinal, tyTypeDesc, tyAlias, tySink, tyUserTypeClass, tyUserTypeClassInst,
-      tyInferred, tyStatic, tyOwned:
+      tyInferred, tyStatic, tyOwned, tyOr:
     g.llType(typ.last, deep)
   of tyEnum:
     llvm.intTypeInContext(g.lc, g.config.getSize(typ).cuint * 8)
@@ -3108,6 +3105,24 @@ proc genTypeInfoV1Base(g: LLGen, typ: PType): llvm.ValueRef =
   else:
     g.nullPtr # g.llMagicType("TNimType").pointerType().constNull()
 
+proc genDeepCopyHook(g: LLGen, typ: PType): llvm.ValueRef =
+  ## Generate the =deepCopy proc for the given type and return its address
+  ## wrapped in the TNimType.deepcopy signature: proc (p: pointer): pointer
+  var op = getAttachedOp(g.graph, typ, attachedDeepCopy)
+  if op == nil:
+    op = getAttachedOp(g.graph, typ.skipTypes(skipPtrs), attachedDeepCopy)
+  if op != nil and getBody(g.graph, op).len > 0:
+    if op.typ == nil or op.typ.callConv != ccNimCall:
+      g.config.internalError(
+        op.name.s & " needs to have the 'nimcall' calling convention"
+      )
+    # Generate the =deepCopy proc body and get its LLVM value
+    let actualFn = g.genFunctionWithBody(op).v
+    # Cast to the deepcopy signature: proc (p: pointer): pointer {.nimcall.}
+    g.b.buildPointerCast(actualFn, g.ptrTy, g.nn("deepcopy_cast"))
+  else:
+    g.nullPtr
+
 proc genTypeInfoV1(
     g: LLGen, typ: PType, typeInfoV2: llvm.ValueRef = nil
 ): llvm.ValueRef =
@@ -3197,7 +3212,7 @@ proc genTypeInfoV1(
           tmp
       else:
         llvm.constNull(els[7])
-    deepcopyVar = llvm.constNull(els[8])
+    deepcopyVar = g.genDeepCopyHook(typ)
 
   result.setInitializer(
     g.genTypeInfoInit(
@@ -3292,6 +3307,9 @@ proc genTypeInfoV2(g: LLGen, typ: PType): llvm.ValueRef =
   if not g.graph.canFormAcycle(typ):
     flags = flags or 1
   let
+    hasNames =
+      g.config.isDefined("nimTypeNames") or g.config.isDefined("nimArcIds") or
+      g.config.isDefined("nimOrcLeakDetector")
     dl = g.m.getModuleDataLayout()
     lt = g.llType(typ)
     destroyImpl = g.genHook(typ, attachedDestructor)
@@ -3317,7 +3335,7 @@ proc genTypeInfoV2(g: LLGen, typ: PType): llvm.ValueRef =
       else:
         g.nullPtr
     nameVar =
-      if isDefined(g.config, "nimTypeNames") and typ.kind in {tyObject, tyDistinct}:
+      if hasNames and typ.kind in {tyObject, tyDistinct}:
         if incompleteType(typ):
           g.config.internalError(
             "request for RTTI generation for incomplete object: " & typeToString(typ)
@@ -3333,18 +3351,13 @@ proc genTypeInfoV2(g: LLGen, typ: PType): llvm.ValueRef =
       else:
         g.nullPtr
     flagsVar = g.constNimInt(flags)
-    vtableVar = constArray(g.ptrTy, [])
-    values =
-      if isDefined(g.config, "nimTypeNames"):
-        @[
-          destroyImpl, sizeVar, alignVar, depthVar, displayVar, nameVar, traceImpl,
-          v1Var, flagsVar, vtableVar,
-        ]
-      else:
-        @[
-          destroyImpl, sizeVar, alignVar, depthVar, displayVar, traceImpl, v1Var,
-          flagsVar, vtableVar,
-        ]
+
+  var values = @[destroyImpl, sizeVar, alignVar, depthVar, displayVar]
+  if hasNames:
+    values.add nameVar
+  values.add [traceImpl, v1Var, flagsVar]
+  if isDefined(g.config, "gcDestructors"):
+    values.add constArray(g.ptrTy, [])
 
   let
     nimTypeTy = g.llMagicType("TNimTypeV2")
@@ -4383,7 +4396,7 @@ proc callReset(g: LLGen, typ: PType, v: LLValue) =
     typ = skipTypes(typ, abstractInst)
     ty = g.llType(typ)
 
-  if supportsMemset(typ): # Fast path
+  if optSeqDestructors in g.config.globalOptions or supportsMemset(typ): # Fast path
     g.buildStoreNull(ty, v.v)
   elif typ.kind in {tyString, tyRef, tySequence}:
     g.genRefAssign(v, constNull(ty))
@@ -5447,6 +5460,8 @@ proc buildLoadVar(g: LLGen, typ: PType, v: llvm.ValueRef): llvm.ValueRef =
   else:
     v
 
+proc genMagicSlice(g: LLGen, n: PNode, load: bool, formalTyp: PType): LLValue
+
 proc genOpenArrayConv(
     g: LLGen, symTyp: PType, n: PNode
 ): (llvm.ValueRef, llvm.ValueRef) =
@@ -5484,7 +5499,24 @@ proc genOpenArrayConv(
         v = g.buildLoadVar(n.typ, ax)
       (g.getNimSeqDataPtr(seqTy, v), g.loadNimSeqLen(v))
     of tyOpenArray, tyVarargs:
-      let ax = g.buildLoadVar(n.typ, g.genNode(n, true).v)
+      let a = block:
+        var q = skipConv(n)
+        var skipped = false
+        while q.kind == nkStmtListExpr and q.len > 0:
+          skipped = true
+          q = q.lastSon
+        if getMagic(q) == mSlice:
+          # magic: pass slice to openArray:
+          if skipped:
+            q = skipConv(n)
+            while q.kind == nkStmtListExpr and q.len > 0:
+              for i in 0 ..< q.len - 1:
+                g.genNode(q[i])
+              q = q.lastSon
+          g.genMagicSlice(q, true, symTyp)
+        else:
+          g.genNode(n, true)
+      let ax = g.buildLoadVar(n.typ, a.v)
       (
         g.b.buildExtractValue(ax, 0, g.nn("p", ax)),
         g.b.buildExtractValue(ax, 1, g.nn("l", ax)),
@@ -5506,6 +5538,17 @@ proc genOpenArrayConv(
         (g.getNimSeqDataPtr(seqTy, v), g.loadNimSeqLen(v))
       of tyArray:
         (g.genNode(n, true).v, g.constNimInt(g.config.lengthOrd(typ.last)))
+      of tyOpenArray, tyVarargs:
+        # ptr/ref openArray: load the struct and extract len
+        var
+          v = g.genNode(n, true).v
+          len = g.buildOpenArrayLenGEP(v)
+          data = g.buildOpenArrayDataGEP(v)
+
+        (
+          g.b.buildLoad2(g.ptrTy, data, "bbbbbbbb"),
+          g.b.buildLoad2(g.primitives[tyInt], len, "aaaaaaaa"),
+        )
       else:
         g.config.internalError(n.info, "Unhandled ref length: " & $typ.last())
         raiseAssert "unreachable"
@@ -5616,7 +5659,7 @@ proc genCallArgs(
     if symTyp.isCompileTimeOnly():
       continue
 
-    if skipTypes(symTyp, abstractVar + {tyStatic}).kind in {tyOpenArray, tyVarargs}:
+    if skipTypes(symTyp, abstractVar).kind in {tyOpenArray, tyVarargs}:
       let (data, len) = g.genOpenArrayConv(symTyp, pr)
       args.add([data, len])
     else:
@@ -5969,7 +6012,7 @@ proc genAsgnNode(g: LLGen, n: PNode, typ: PType, dest: LLValue): LLValue =
   # genNode, but for use as RHS in a call to genAssignment - requires special
   # care to convert things to openArray since this is not handled by the AST
   # typ is the destination type
-  if skipTypes(typ, abstractVar + {tyStatic}).kind in {tyOpenArray, tyVarargs}:
+  if skipTypes(typ, abstractInst).kind in {tyOpenArray, tyVarargs}:
     let (data, len) = g.genOpenArrayConv(typ, n)
     LLValue(v: g.buildOpenArray(data, len), lode: n)
   else:
@@ -6535,12 +6578,11 @@ proc genCallMagic(g: LLGen, n: PNode, load: bool, dest: LLValue): LLValue =
 
   g.genCall(nil, n, load, dest)
 
-proc genMagicSlice(g: LLGen, n: PNode, load: bool): LLValue =
+proc genMagicSlice(g: LLGen, n: PNode, load: bool, formalTyp: PType): LLValue =
   let
     bx = g.genNode(n[2], true).v
     cx = g.genNode(n[3], true).v
     typ = n[1].typ.skipTypes(abstractVar + {tyPtr})
-
   var v, len: llvm.ValueRef
   case typ.kind
   of tyArray:
@@ -6577,7 +6619,8 @@ proc genMagicSlice(g: LLGen, n: PNode, load: bool): LLValue =
     let
       prepareForMutation =
         optSeqDestructors in g.config.globalOptions and typ.kind == tyString and
-        (n[1].kind == nkHiddenDeref or n.typ.skipTypes(abstractInst).kind == tyVar)
+        (n[1].kind == nkHiddenDeref or formalTyp.skipTypes(abstractInst).kind == tyVar)
+
       axp = g.genNode(n[1], not prepareForMutation)
       ax =
         if prepareForMutation:
@@ -6622,9 +6665,7 @@ proc genMagicSizeOf(g: LLGen, n: PNode): LLValue =
   LLValue(v: g.constNimInt(dl.aBISizeOfType(g.llType(t)).int))
 
 proc genMagicAlignOf(g: LLGen, n: PNode): LLValue =
-  let
-    t = n[1].typ.skipTypes({tyTypeDesc})
-    dl = g.m.getModuleDataLayout()
+  let t = n[1].typ.skipTypes({tyTypeDesc})
 
   LLValue(v: g.constNimInt(g.getBestAlign(t, g.llType(t))))
 
@@ -7947,24 +7988,22 @@ proc genMagicMove(g: LLGen, n: PNode, load: bool): LLValue =
       if op == nil:
         g.callReset(n[1].skipAddr.typ, ax)
       else:
+        let
+          f = g.genFunctionWithBody(op).v
+          fty = f.globalGetValueType()
         case skipTypes(n[1].skipAddr.typ, abstractVar + {tyStatic}).kind
         of tyOpenArray, tyVarargs:
-          # todo fixme generated `wasMoved` hooks for
-          # openarrays, but it probably shouldn't?
-          raiseAssert "TODO"
-          # var s: string
-          # if reifiedOpenArray(a.lode):
-          #   if a.t.kind in {tyVar, tyLent}:
-          #     s = "$1->Field0, $1->Field1" % [rdLoc(a)]
-          #   else:
-          #     s = "$1.Field0, $1.Field1" % [rdLoc(a)]
-          # else:
-          #   s = "$1, $1Len_0" % [rdLoc(a)]
-          # linefmt(p, cpsStmts, "$1($2);$n", [rdLoc(b), s])
+          let oa = g.b.buildLoad2(g.llOpenArrayType(), ax.v)
+          discard g.b.buildCall2(
+            fty,
+            f,
+            [
+              g.b.buildExtractValue(oa, 0, g.nn("p", ax.v)),
+              g.b.buildExtractValue(oa, 1, g.nn("l", ax.v)),
+            ],
+            "",
+          )
         else:
-          let
-            f = g.genFunctionWithBody(op).v
-            fty = f.globalGetValueType()
           discard g.b.buildCall2(fty, f, [ax.v], "")
     else:
       if n[1].kind == nkSym and isSinkParam(n[1].sym):
@@ -8441,7 +8480,7 @@ proc genMagic(g: LLGen, n: PNode, load: bool, dest: LLValue): LLValue =
     # TODO these are magics, but for some reason they don't have the loc.snippet set
     result = g.genCall(nil, n, load, dest)
   of mSlice:
-    result = g.genMagicSlice(n, load)
+    result = g.genMagicSlice(n, load, n.typ)
   of mEnsureMove:
     result = g.genNode(n[1], load)
   else:
@@ -8543,7 +8582,6 @@ proc genNodeStrLit(g: LLGen, n: PNode, load: bool): LLValue =
   let
     tt =
       if n.typ == nil:
-        # debugEcho "TODO nil-typ strlit", n
         getSysType(g.graph, n.info, tyString)
       else:
         n.typ
@@ -8735,6 +8773,8 @@ proc genNodeObjConstr(g: LLGen, n: PNode, load: bool, dest: LLValue): LLValue =
       dest
   for i in 1 ..< n.len:
     let s = n[i]
+    if nfPreventCg in s.flags:
+      continue # inactive case branch
 
     if s.len == 3 and optFieldCheck in g.f.options:
       g.genFieldCheck(s[2], v, s[0].sym)

--- a/nlvm/nlvm.nim
+++ b/nlvm/nlvm.nim
@@ -6,8 +6,8 @@ import
   std/[browsers, sequtils, parseopt, strutils, times, os],
   llvm/llvm,
   compiler/[
-    ast, cmdlinehelper, commands, condsyms, extccomp, idents, lexer, lineinfos,
-    llstream, modulegraphs, modules, msgs, options, passes, passaux, pathutils, platform,
+    ast, cmdlinehelper, commands, condsyms, extccomp, idents, lineinfos, llstream,
+    modulegraphs, modules, msgs, options, passes, passaux, pathutils, platform,
   ],
   ./[llgen, lllink, llplatform]
 
@@ -186,23 +186,6 @@ proc commandCompile(graph: ModuleGraph) =
 
   passes.compileProject(graph)
 
-proc commandScan(conf: ConfigRef) =
-  var f = addFileExt(mainCommandArg(conf), NimExt)
-  var stream = llStreamOpen(f.AbsoluteFile, fmRead)
-  if stream != nil:
-    var
-      L: Lexer = default(Lexer)
-      tok: Token = default(Token)
-    openLexer(L, f.AbsoluteFile, stream, newIdentCache(), conf)
-    while true:
-      rawGetTok(L, tok)
-      conf.printTok(tok)
-      if tok.tokType == tkEof:
-        break
-    closeLexer(L)
-  else:
-    conf.rawMessage(errCannotOpenFile, f)
-
 proc commandCheck(graph: ModuleGraph) =
   graph.config.errorMax = high(int) # do not stop after first error
   defineSymbol(graph.config.symbols, "nimcheck")
@@ -354,9 +337,6 @@ proc handleCmdLine(cache: IdentCache, conf: ConfigRef) =
   # C++-specific quirks
   conf.exc = excSetjmp
 
-  if conf.selectedGC == gcUnselected:
-    initOrcDefines(conf)
-
   if conf.cmd == cmdCrun:
     conf.verbosity = 0
     conf.notes = NotesVerbosity[0]
@@ -367,6 +347,10 @@ proc handleCmdLine(cache: IdentCache, conf: ConfigRef) =
   var graph = newModuleGraph(cache, conf)
   if not self.loadConfigsAndProcessCmdLine(cache, conf, graph):
     return
+
+  if conf.selectedGC == gcUnselected:
+    initOrcDefines(conf)
+
   mainCommand(graph)
 
   if conf.hasHint(hintGCStats):
@@ -392,7 +376,8 @@ proc handleCmdLine(cache: IdentCache, conf: ConfigRef) =
         cmdPrefix.add " "
         # without the `cmdPrefix.len > 0` check, on windows you'd get a cryptic:
         # `The parameter is incorrect`
-      execExternalProgram(conf, cmdPrefix & output.quoteShell & ' ' & conf.arguments)
+      let cmd = cmdPrefix & output.quoteShell & ' ' & conf.arguments
+      execExternalProgram(conf, cmd.strip(leading = false, trailing = true))
     of cmdDocLike, cmdRst2html, cmdRst2tex: # bugfix(cmdRst2tex was missing)
       if conf.arguments.len > 0:
         # reserved for future use

--- a/skipped-tests.txt
+++ b/skipped-tests.txt
@@ -5,12 +5,7 @@ lib/nimrtl.nim c  -d:nimDebugDlOpen --outdir:tests/dll # Compiler/internal / reN
 tests/align/talign.nim c --mm:orc # Unclassified / reCodeNotFound
 tests/align/talign.nim c --mm:refc -d:useGcAssert -d:useSysAssert # Unclassified / reCodeNotFound
 tests/arc/t16458.nim c --gc:orc --d:useNimRtl # Linker/nimrtl / reNimcCrash
-tests/arc/tarcmisc.nim c # Runtime Crash / reExitcodesDiffer
 tests/arc/tasyncleak.nim c # Memory/count / reOutputsDiffer
-tests/arc/tcaseobjcopy.nim c # Memory/leak / reExitcodesDiffer
-tests/arc/tcaseobj.nim c # Memory/leak / reExitcodesDiffer
-tests/arc/tclosureiter.nim c # Memory/count / reOutputsDiffer
-tests/arc/tdeepcopy.nim c # Unclassified / reOutputsDiffer
 tests/arc/thard_alignment.nim c # Linker / reNimcCrash
 tests/assert/t21195.nim c --verbosity:0 --os:standalone --mm:none # Compiler/error / reNimcCrash
 tests/assert/tassert_c.nim c -d:nimPreviewSlimSystem --stackTrace:on --excessiveStackTrace:off # Unclassified / reOutputsDiffer
@@ -49,7 +44,6 @@ tests/compiler/tcmdlineclib.nim c # Compiler/error / reNimcCrash
 tests/compiles/tstaticlib.nim c # Assertion / reExitcodesDiffer
 tests/consts/taddressable_consts2.nim c # Linker / reNimcCrash
 tests/consts/taddressable_consts.nim c # Linker / reNimcCrash
-tests/converter/tgenericconverter.nim c # Compiler/internal / reNimcCrash
 tests/coroutines/tgc.nim c --gc:arc # Runtime Crash / reExitcodesDiffer
 tests/coroutines/tgc.nim c --gc:orc # Runtime Crash / reExitcodesDiffer
 tests/coroutines/tgc.nim c --gc:refc # Runtime Crash / reExitcodesDiffer
@@ -66,17 +60,8 @@ tests/c/temit.nim c # Pragmas/{.emit.} / reNimcCrash
 tests/c/timportedsize.nim c # Pragmas/{.emit.} / reNimcCrash
 tests/destructor/t23837.nim c --cursorinference:off # Pragmas/{.emit.} / reNimcCrash
 tests/destructor/t23837.nim c --cursorinference:on # Pragmas/{.emit.} / reNimcCrash
-tests/destructor/tbintree2.nim c # Compiler/error / reNimcCrash
-tests/destructor/tconsume_twice.nim c # Unclassified / reMsgsDiffer
 tests/destructor/tcycle3.nim c # Runtime Crash / reExitcodesDiffer
-tests/destructor/tdangingref_simple.nim c # Compiler/error / reNimcCrash
-tests/destructor/texceptions.nim c # Unclassified / reOutputsDiffer
-tests/destructor/tgotoexc_leak.nim c # Unclassified / reOutputsDiffer
-tests/destructor/tnewruntime_misc.nim c # Compiler/error / reNimcCrash
-tests/destructor/tuse_ownedref_after_move.nim c # Unclassified / reMsgsDiffer
-tests/destructor/tv2_raise.nim c # Compiler/error / reNimcCrash
-tests/destructor/twidgets.nim c # Compiler/error / reNimcCrash
-tests/destructor/twidgets_unown.nim c # Compiler/error / reNimcCrash
+tests/destructor/tv2_raise.nim c # Memory/leak / reExitcodesDiffer
 tests/dll/client.nim c  -d:nimDebugDlOpen -d:release --gc:boehm --threads:on # Linker/nimrtl / reNimcCrash
 tests/dll/client.nim c  -d:nimDebugDlOpen -d:release --mm:refc --threads:on # Linker/nimrtl / reNimcCrash
 tests/dll/client.nim c  -d:nimDebugDlOpen -d:release --threads:on # Linker/nimrtl / reNimcCrash
@@ -124,8 +109,6 @@ tests/ic/thallo_temp.nim c  --incremental:on -d:nimIcIntegrityChecks # Assertion
 tests/ic/timports_temp.nim c  --incremental:on -d:nimIcIntegrityChecks # Assertion / reNimcCrash
 tests/ic/tmethods_temp.nim c  --incremental:on -d:nimIcIntegrityChecks # Assertion / reNimcCrash
 tests/ic/tstdlib_import_changed_temp.nim c  --incremental:on -d:nimIcIntegrityChecks # Assertion / reNimcCrash
-tests/int/tints.nim js --backend:js --jsbigint64:off -d:nimStringHash2 # Compiler/error / reNimcCrash
-tests/int/tints.nim js --backend:js --jsbigint64:on # Compiler/error / reNimcCrash
 tests/iter/tnestedclosures.nim c # LLVM IR / reNimcCrash
 tests/iter/tshallowcopy_closures.nim c --mm:refc # Unclassified / reCodeNotFound
 tests/iter/tyieldintry.nim c --experimental:strictdefs # Runtime Crash / reExitcodesDiffer
@@ -161,50 +144,29 @@ tests/nimdoc/t15916.nim c # Compiler/error / reNimcCrash
 tests/nimdoc/t17615.nim c # Unclassified / reMsgsDiffer
 tests/nimdoc/trunnableexamples.nim c # Compiler/error / reNimcCrash
 tests/niminaction/Chapter8/sdl/sdl_test.nim c # Linker / reNimcCrash
-tests/objects/tobject_default_value.nim c -d:nimPreviewRangeDefault --mm:refc # Runtime Crash / reExitcodesDiffer
-tests/objects/tobject_default_value.nim c -d:nimPreviewRangeDefault --warningAsError:ProveInit --mm:orc # Assertion / reExitcodesDiffer
 tests/osproc/treadlines.nim c # LLVM IR / reOutputsDiffer
 tests/overflow/toverflow.nim c --overflowChecks:off # Assertion / reExitcodesDiffer
-tests/overflow/toverflow.nim js --overflowChecks:off --b:js # Compiler/error / reNimcCrash
 tests/overflow/toverflow_reorder.nim c # Assertion / reExitcodesDiffer
 tests/overload/tstatic_with_converter.nim c # Pragmas/{.emit.} / reNimcCrash
-tests/parallel/tdeepcopy2.nim c --mm:refc # Unclassified / reOutputsDiffer
-tests/parallel/tdeepcopy.nim c --mm:refc # Unclassified / reOutputsDiffer
 tests/parallel/tmissing_deepcopy.nim c --mm:refc # Unclassified / reCodeNotFound
 tests/pragmas/tbitsize.nim c # Assertion / reExitcodesDiffer
 tests/pragmas/tnoreturn.nim c --mm:refc # Unclassified / reCodeNotFound
 tests/pragmas/tpush.nim c # Compiler/error / reExitcodesDiffer
 tests/pragmas/treorder.nim c # Compiler/error / reNimcCrash
 tests/realtimeGC/tmain.nim c # Linker / reNimcCrash
-tests/stdlib/thashes.nim js --backend:js -d:nimStringHash2 # Compiler/error / reNimcCrash
-tests/stdlib/thashes.nim js --backend:js --jsbigint64:on # Compiler/error / reNimcCrash
-tests/stdlib/tjson.nim c # Assertion / reExitcodesDiffer
-tests/stdlib/tjson.nim cpp --backend:cpp # Assertion / reExitcodesDiffer
-tests/stdlib/tjson.nim js --backend:js --jsbigint64:off -d:nimStringHash2 # Compiler/error / reNimcCrash
-tests/stdlib/tjson.nim js --backend:js --jsbigint64:on # Compiler/error / reNimcCrash
 tests/stdlib/tmath.nim c # Assertion / reExitcodesDiffer
 tests/stdlib/tmath.nim c -d:danger # Assertion / reExitcodesDiffer
 tests/stdlib/tmath.nim c --mm:refc # Assertion / reExitcodesDiffer
 tests/stdlib/tmisc_issues.nim c --mm:refc # Assertion / reExitcodesDiffer
 tests/stdlib/tosproc.nim c --mm:orc # Assertion / reExitcodesDiffer
 tests/stdlib/tosproc.nim c --mm:refc # Assertion / reExitcodesDiffer
-tests/stdlib/trandom.nim js --backend:js --jsbigint64:off -d:nimStringHash2 # Compiler/error / reNimcCrash
-tests/stdlib/trandom.nim js --backend:js --jsbigint64:on # Compiler/error / reNimcCrash
 tests/stdlib/trationals.nim c --mm:orc # Compiler/error / reNimcCrash
 tests/stdlib/trationals.nim c --mm:refc # Compiler/error / reNimcCrash
 tests/stdlib/tssl.nim c --mm:orc # Compiler/error / reExitcodesDiffer
 tests/stdlib/tssl.nim c --mm:refc # Compiler/error / reExitcodesDiffer
 tests/stdlib/tstackframes.nim c # Pragmas/{.emit.} / reExitcodesDiffer
 tests/stdlib/tstdlib_various.nim c --mm:refc # Unclassified / reExitcodesDiffer
-tests/stdlib/tstring.nim js --backend:js --mm:orc # Compiler/error / reNimcCrash
-tests/stdlib/tstring.nim js --backend:js --mm:refc # Compiler/error / reNimcCrash
-tests/stdlib/tstrutils.nim js --backend:js --jsbigint64:off -d:nimStringHash2 # Compiler/error / reNimcCrash
-tests/stdlib/tstrutils.nim js --backend:js --jsbigint64:on # Compiler/error / reNimcCrash
-tests/stdlib/ttimes.nim js --backend:js --jsbigint64:off -d:nimStringHash2 # Compiler/error / reNimcCrash
-tests/stdlib/ttimes.nim js --backend:js --jsbigint64:on # Compiler/error / reNimcCrash
 tests/stdlib/tvolatile.nim c # Pragmas/{.emit.} / reNimcCrash
-tests/system/tdollars.nim js --backend:js --jsbigint64:off -d:nimStringHash2 # Compiler/error / reNimcCrash
-tests/system/tdollars.nim js --backend:js --jsbigint64:on # Compiler/error / reNimcCrash
 tests/system/tgogc.nim c # LLVM IR / reNimcCrash
 tests/system/tnim_stacktrace_override.nim c # Compiler/error / reOutputsDiffer
 tests/template/tcallsitelineinfo2.nim c # Compiler/error / reOutputsDiffer
@@ -215,8 +177,4 @@ tests/testament/tshould_not_work.nim c # Assertion / reExitcodesDiffer
 tests/tools/tctags2.nim c # Compiler/error / reNimcCrash
 tests/tools/tctags.nim c # Compiler/error / reNimcCrash
 tests/tools/tnimgrep.nim c # Unclassified / reExitcodesDiffer
-tests/views/tsplit_into_seq.nim c # Compiler/internal / reNimcCrash
-tests/views/tsplit_into_table.nim c # Assertion / reNimcCrash
-tests/vm/tcaseobj.nim c # Assertion / reExitcodesDiffer
-tests/vm/tvmmisc.nim c # Assertion / reExitcodesDiffer
 tests/vm/tvmops.nim c # Assertion / reNimcCrash


### PR DESCRIPTION
* set the 'deepcopy' field in TNimType for types that have a custom =deepCopy proc defined.
* fix exception handling memory leak with arc/orc not freeing the exception
* abort instead of quit on unhandled exception
* reset instances with `memset` instead of complex reset function in orc/arc
* fix openArray for var params / moves / etc
* fix --newruntime / gcHooks compile-time defines